### PR TITLE
Temporarily removed output clause from MERGE

### DIFF
--- a/Simpleverse.Dapper/Simpleverse.Dapper.csproj
+++ b/Simpleverse.Dapper/Simpleverse.Dapper.csproj
@@ -13,10 +13,10 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageTags>Dapper, Bulk, Merge, Upsert, Delete, Insert, Update</PackageTags>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <Version>1.0.12</Version>
+    <Version>1.0.13</Version>
     <Description>High performance operation for MS SQL Server built for Dapper ORM. Including bulk operations Insert, Update, Delete, Get as well as Upsert both single and bulk.</Description>
-    <AssemblyVersion>1.0.12.0</AssemblyVersion>
-    <FileVersion>1.0.12.0</FileVersion>
+    <AssemblyVersion>1.0.13.0</AssemblyVersion>
+    <FileVersion>1.0.13.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Simpleverse.Dapper/SqlServer/Merge/MergeExtensions.cs
+++ b/Simpleverse.Dapper/SqlServer/Merge/MergeExtensions.cs
@@ -72,7 +72,7 @@ namespace Simpleverse.Dapper.SqlServer.Merge
 			MergeMatchResult.Matched.Format(typeMeta, matched, sb);
 			MergeMatchResult.NotMatchedBySource.Format(typeMeta, notMatchedBySource, sb);
 			MergeMatchResult.NotMatchedByTarget.Format(typeMeta, notMatchedByTarget, sb);
-			MergeOutputFormat(typeMeta.PropertiesKey.Union(typeMeta.PropertiesComputed).ToList(), sb);
+			// MergeOutputFormat(typeMeta.PropertiesKey.Union(typeMeta.PropertiesComputed).ToList(), sb);
 			sb.Append(";");
 
 			var merged = await connection.ExecuteAsync(sb.ToString(), entitiesToMerge, commandTimeout: commandTimeout, transaction: transaction);


### PR DESCRIPTION
Temporarily removed output clause from MERGE due to conflicts when using it combined with triggers on the target table. This should be revisited to implement a different approach to the output clause for the purpose of capturing changes.