### PR TITLE
Fixed key properties condition on MergeBulkAsync

### DIFF
--- a/src/Simpleverse.Repository.Db.Test/SqlServer/Merge/MergeTests.cs
+++ b/src/Simpleverse.Repository.Db.Test/SqlServer/Merge/MergeTests.cs
@@ -39,7 +39,8 @@ namespace Simpleverse.Repository.Db.Test.SqlServer.Merge
 							options.CheckConditionOnColumns();
 						},
 						notMatchedByTarget: options => options.Insert(),
-						notMatchedBySource: options => options.Delete()
+						notMatchedBySource: options => options.Delete(),
+						outputMap: OutputMapper.Map
 					)
 					.Result;
 

--- a/src/Simpleverse.Repository.Db/Simpleverse.Repository.Db.csproj
+++ b/src/Simpleverse.Repository.Db/Simpleverse.Repository.Db.csproj
@@ -13,10 +13,10 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageTags>Dapper, Bulk, Merge, Upsert, Delete, Insert, Update, Repository</PackageTags>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <Version>2.1.20</Version>
+    <Version>2.1.21</Version>
     <Description>High performance operation for MS SQL Server built for Dapper ORM. Including bulk operations Insert, Update, Delete, Get as well as Upsert both single and bulk.</Description>
-    <AssemblyVersion>2.1.20.0</AssemblyVersion>
-    <FileVersion>2.1.20.0</FileVersion>
+    <AssemblyVersion>2.1.21.0</AssemblyVersion>
+    <FileVersion>2.1.21.0</FileVersion>
     <RepositoryUrl>https://github.com/lukaferlez/Simpleverse.Repository</RepositoryUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <EmbedAllSources>true</EmbedAllSources>

--- a/src/Simpleverse.Repository.Db/SqlServer/Merge/MergeExtensions.cs
+++ b/src/Simpleverse.Repository.Db/SqlServer/Merge/MergeExtensions.cs
@@ -141,7 +141,7 @@ namespace Simpleverse.Repository.Db.SqlServer.Merge
 					var outputClause = string.Empty;
 					if (mapGeneratedValues)
 					{
-						if (typeMeta.PropertiesKey.Any())
+						if (typeMeta.PropertiesKeyAndExplicit.Any())
 						{
 							var outputTarget = await connection.CreateTemporaryTableFromTable(
 								typeMeta.TableName,


### PR DESCRIPTION
Fixed key properties condition on MergeBulkAsync. 
Check is added for explicit keys, if not, Temporary output table is not generated which resolve in errors while Upserting.