### PR TITLE
🐞Fix:  Cylic reference in QueryBuilder Where()

### DIFF
--- a/src/Simpleverse.Repository.Db/QueryBuilder.cs
+++ b/src/Simpleverse.Repository.Db/QueryBuilder.cs
@@ -483,7 +483,7 @@ namespace Simpleverse.Repository.Db
 			Func<Func<Expression<Func<TTable, object>>, Selector>, string> selectorBuilder
 		)
 		{
-			this.Where(selectorBuilder);
+			this.Where(Table, selectorBuilder);
 			return this;
 		}
 

--- a/src/Simpleverse.Repository.Db/Simpleverse.Repository.Db.csproj
+++ b/src/Simpleverse.Repository.Db/Simpleverse.Repository.Db.csproj
@@ -13,10 +13,10 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageTags>Dapper, Bulk, Merge, Upsert, Delete, Insert, Update, Repository</PackageTags>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <Version>2.1.22</Version>
+    <Version>2.1.23</Version>
     <Description>High performance operation for MS SQL Server built for Dapper ORM. Including bulk operations Insert, Update, Delete, Get as well as Upsert both single and bulk.</Description>
-    <AssemblyVersion>2.1.22.0</AssemblyVersion>
-    <FileVersion>2.1.22.0</FileVersion>
+    <AssemblyVersion>2.1.23.0</AssemblyVersion>
+    <FileVersion>2.1.23.0</FileVersion>
     <RepositoryUrl>https://github.com/lukaferlez/Simpleverse.Repository</RepositoryUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <EmbedAllSources>true</EmbedAllSources>


### PR DESCRIPTION
In the current implementation, calling : ``` queryBuilder.Where(c => $"({c(x => x.ChannelOne).IsNotNull()} OR {c(x => x.ChannelTwo).IsNotNull()})")``` causes the application to crash due to an infinite loop. With the fix applied, the issue is resolved and the application works as expected.