### PR TITLE
✨feat: Add CancellationToken support to all async methods

### DIFF
--- a/src/Simpleverse.Repository.Db.Test/SqlServer/Entity/CancellationTokenTests.cs
+++ b/src/Simpleverse.Repository.Db.Test/SqlServer/Entity/CancellationTokenTests.cs
@@ -1,0 +1,173 @@
+using Simpleverse.Repository.Db.Extensions;
+using Simpleverse.Repository.Db.SqlServer;
+using StackExchange.Profiling.Data;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Simpleverse.Repository.Db.Test.SqlServer.Entity
+{
+	[Collection("SqlServerCollection")]
+	public class CancellationTokenTests : DatabaseTestFixture
+	{
+		private readonly SqlRepository _sqlRepository;
+
+		public CancellationTokenTests(DatabaseFixture fixture, ITestOutputHelper output)
+			: base(fixture, output)
+		{
+			_sqlRepository = new SqlRepository(() => (ProfiledDbConnection)fixture.GetProfiledConnection());
+		}
+
+		[Fact]
+		public async Task ListAsync_WhenCancellationTokenCancelled_ThrowsOperationCanceledException()
+		{
+			using (var profiler = Profile())
+			using (var connection = _fixture.GetProfiledConnection())
+			{
+				// arrange
+				connection.Open();
+				connection.Truncate<Identity>();
+				var entity = new IdentityEntity(_sqlRepository);
+				var cancelledToken = new CancellationToken(canceled: true);
+
+				// act & assert
+				await Assert.ThrowsAnyAsync<OperationCanceledException>(
+					() => entity.ListAsync(cancellationToken: cancelledToken)
+				);
+			}
+		}
+
+		[Fact]
+		public async Task GetAsync_WhenCancellationTokenCancelled_ThrowsOperationCanceledException()
+		{
+			using (var profiler = Profile())
+			using (var connection = _fixture.GetProfiledConnection())
+			{
+				// arrange
+				connection.Open();
+				connection.Truncate<Identity>();
+				var entity = new IdentityEntity(_sqlRepository);
+				var cancelledToken = new CancellationToken(canceled: true);
+
+				// act & assert
+				await Assert.ThrowsAnyAsync<OperationCanceledException>(
+					() => entity.GetAsync(cancellationToken: cancelledToken)
+				);
+			}
+		}
+
+		[Fact]
+		public async Task AddAsync_WhenCancellationTokenCancelled_ThrowsOperationCanceledException()
+		{
+			using (var profiler = Profile())
+			using (var connection = _fixture.GetProfiledConnection())
+			{
+				// arrange
+				connection.Open();
+				connection.Truncate<Identity>();
+				var entity = new IdentityEntity(_sqlRepository);
+				var records = TestData.IdentityWithoutIdData(1);
+				var cancelledToken = new CancellationToken(canceled: true);
+
+				// act & assert
+				await Assert.ThrowsAnyAsync<OperationCanceledException>(
+					() => entity.AddAsync(records, cancellationToken: cancelledToken)
+				);
+			}
+		}
+
+		[Fact]
+		public async Task UpdateAsync_WhenCancellationTokenCancelled_ThrowsOperationCanceledException()
+		{
+			using (var profiler = Profile())
+			using (var connection = _fixture.GetProfiledConnection())
+			{
+				// arrange
+				connection.Open();
+				connection.Truncate<Identity>();
+				var entity = new IdentityEntity(_sqlRepository);
+				var cancelledToken = new CancellationToken(canceled: true);
+
+				// act & assert
+				await Assert.ThrowsAnyAsync<OperationCanceledException>(
+					() => entity.UpdateAsync(
+						update => update.Name = "test",
+						cancellationToken: cancelledToken
+					)
+				);
+			}
+		}
+
+		[Fact]
+		public async Task DeleteAsync_WhenCancellationTokenCancelled_ThrowsOperationCanceledException()
+		{
+			using (var profiler = Profile())
+			using (var connection = _fixture.GetProfiledConnection())
+			{
+				// arrange
+				connection.Open();
+				connection.Truncate<Identity>();
+				var entity = new IdentityEntity(_sqlRepository);
+				var cancelledToken = new CancellationToken(canceled: true);
+
+				// act & assert
+				await Assert.ThrowsAnyAsync<OperationCanceledException>(
+					() => entity.DeleteAsync(cancellationToken: cancelledToken)
+				);
+			}
+		}
+
+		[Fact]
+		public async Task ExistsAsync_WhenCancellationTokenCancelled_ThrowsOperationCanceledException()
+		{
+			using (var profiler = Profile())
+			using (var connection = _fixture.GetProfiledConnection())
+			{
+				// arrange
+				connection.Open();
+				connection.Truncate<Identity>();
+				var entity = new IdentityEntity(_sqlRepository);
+				var cancelledToken = new CancellationToken(canceled: true);
+
+				// act & assert
+				await Assert.ThrowsAnyAsync<OperationCanceledException>(
+					() => entity.ExistsAsync(cancellationToken: cancelledToken)
+				);
+			}
+		}
+
+		[Fact]
+		public async Task DbRepository_QueryAsync_WhenCancellationTokenCancelled_ThrowsOperationCanceledException()
+		{
+			using (var profiler = Profile())
+			{
+				// arrange
+				var cancelledToken = new CancellationToken(canceled: true);
+
+				// act & assert
+				await Assert.ThrowsAnyAsync<OperationCanceledException>(
+					() => _sqlRepository.QueryAsync<Identity>("SELECT 1", null, cancelledToken)
+				);
+			}
+		}
+
+		[Fact]
+		public async Task DbRepository_ExecuteAsync_WhenCancellationTokenCancelled_ThrowsOperationCanceledException()
+		{
+			using (var profiler = Profile())
+			{
+				// arrange
+				var builder = new QueryBuilder<Identity>();
+				var query = builder.AddTemplate("SELECT 1");
+				var cancelledToken = new CancellationToken(canceled: true);
+
+				// act & assert
+				await Assert.ThrowsAnyAsync<OperationCanceledException>(
+					() => _sqlRepository.ExecuteAsync(query, cancelledToken)
+				);
+			}
+		}
+	}
+}

--- a/src/Simpleverse.Repository.Db/DbConnectionExtensions.cs
+++ b/src/Simpleverse.Repository.Db/DbConnectionExtensions.cs
@@ -1,57 +1,58 @@
-﻿using Dapper;
+using Dapper;
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Simpleverse.Repository.Db
 {
 	public static class DbConnectionExtensions
 	{
-		public static Task<IEnumerable<R>> QueryAsync<R>(this IDbConnection conn, SqlBuilder.Template query, IDbTransaction tran = null)
-			=> conn.QueryAsync<R>(query.RawSql, param: query.Parameters, transaction: tran);
+		public static Task<IEnumerable<R>> QueryAsync<R>(this IDbConnection conn, SqlBuilder.Template query, IDbTransaction tran = null, CancellationToken cancellationToken = default)
+			=> conn.QueryAsync<R>(new CommandDefinition(query.RawSql, query.Parameters, transaction: tran, cancellationToken: cancellationToken));
 
-		public static Task<IEnumerable<dynamic>> QueryAsync(this IDbConnection conn, SqlBuilder.Template query, IDbTransaction tran = null)
-			=> conn.QueryAsync(query.RawSql, param: query.Parameters, transaction: tran);
+		public static Task<IEnumerable<dynamic>> QueryAsync(this IDbConnection conn, SqlBuilder.Template query, IDbTransaction tran = null, CancellationToken cancellationToken = default)
+			=> conn.QueryAsync(new CommandDefinition(query.RawSql, query.Parameters, transaction: tran, cancellationToken: cancellationToken));
 
-		public static Task<IEnumerable<(TFirst, TSecond)>> QueryAsync<TFirst, TSecond>(this IDbConnection conn, SqlBuilder.Template query, IDbTransaction tran)
-			=> conn.QueryAsync<TFirst, TSecond>(query.RawSql, param: query.Parameters, tran: tran);
+		public static Task<IEnumerable<(TFirst, TSecond)>> QueryAsync<TFirst, TSecond>(this IDbConnection conn, SqlBuilder.Template query, IDbTransaction tran, CancellationToken cancellationToken = default)
+			=> conn.QueryAsync<TFirst, TSecond>(query.RawSql, param: query.Parameters, tran: tran, cancellationToken: cancellationToken);
 
-		public static Task<IEnumerable<(TFirst, TSecond, TThrid)>> QueryAsync<TFirst, TSecond, TThrid>(this IDbConnection conn, SqlBuilder.Template query, IDbTransaction tran = null)
-			=> conn.QueryAsync<TFirst, TSecond, TThrid>(query.RawSql, param: query.Parameters, tran: tran);
+		public static Task<IEnumerable<(TFirst, TSecond, TThrid)>> QueryAsync<TFirst, TSecond, TThrid>(this IDbConnection conn, SqlBuilder.Template query, IDbTransaction tran = null, CancellationToken cancellationToken = default)
+			=> conn.QueryAsync<TFirst, TSecond, TThrid>(query.RawSql, param: query.Parameters, tran: tran, cancellationToken: cancellationToken);
 
-		public static Task<IEnumerable<(TFirst, TSecond, TThrid, TFourth)>> QueryAsync<TFirst, TSecond, TThrid, TFourth>(this IDbConnection conn, SqlBuilder.Template query, IDbTransaction tran = null)
-			=> conn.QueryAsync<TFirst, TSecond, TThrid, TFourth>(query.RawSql, param: query.Parameters, tran: tran);
+		public static Task<IEnumerable<(TFirst, TSecond, TThrid, TFourth)>> QueryAsync<TFirst, TSecond, TThrid, TFourth>(this IDbConnection conn, SqlBuilder.Template query, IDbTransaction tran = null, CancellationToken cancellationToken = default)
+			=> conn.QueryAsync<TFirst, TSecond, TThrid, TFourth>(query.RawSql, param: query.Parameters, tran: tran, cancellationToken: cancellationToken);
 
-		public static Task<IEnumerable<(TFirst, TSecond, TThrid, TFourth, TFifth)>> QueryAsync<TFirst, TSecond, TThrid, TFourth, TFifth>(this IDbConnection conn, SqlBuilder.Template query, IDbTransaction tran = null)
-			=> conn.QueryAsync<TFirst, TSecond, TThrid, TFourth, TFifth>(query.RawSql, param: query.Parameters, tran: tran);
+		public static Task<IEnumerable<(TFirst, TSecond, TThrid, TFourth, TFifth)>> QueryAsync<TFirst, TSecond, TThrid, TFourth, TFifth>(this IDbConnection conn, SqlBuilder.Template query, IDbTransaction tran = null, CancellationToken cancellationToken = default)
+			=> conn.QueryAsync<TFirst, TSecond, TThrid, TFourth, TFifth>(query.RawSql, param: query.Parameters, tran: tran, cancellationToken: cancellationToken);
 
-		public static Task<IEnumerable<(TFirst, TSecond, TThrid, TFourth, TFifth, TSixth)>> QueryAsync<TFirst, TSecond, TThrid, TFourth, TFifth, TSixth>(this IDbConnection conn, SqlBuilder.Template query, IDbTransaction tran = null)
-			=> conn.QueryAsync<TFirst, TSecond, TThrid, TFourth, TFifth, TSixth>(query.RawSql, param: query.Parameters, tran: tran);
+		public static Task<IEnumerable<(TFirst, TSecond, TThrid, TFourth, TFifth, TSixth)>> QueryAsync<TFirst, TSecond, TThrid, TFourth, TFifth, TSixth>(this IDbConnection conn, SqlBuilder.Template query, IDbTransaction tran = null, CancellationToken cancellationToken = default)
+			=> conn.QueryAsync<TFirst, TSecond, TThrid, TFourth, TFifth, TSixth>(query.RawSql, param: query.Parameters, tran: tran, cancellationToken: cancellationToken);
 
-		public static Task<IEnumerable<(TFirst, TSecond, TThrid, TFourth, TFifth, TSixth, TSeventh)>> QueryAsync<TFirst, TSecond, TThrid, TFourth, TFifth, TSixth, TSeventh>(this IDbConnection conn, SqlBuilder.Template query, IDbTransaction tran = null)
-			=> conn.QueryAsync<TFirst, TSecond, TThrid, TFourth, TFifth, TSixth, TSeventh>(query.RawSql, param: query.Parameters, tran: tran);
+		public static Task<IEnumerable<(TFirst, TSecond, TThrid, TFourth, TFifth, TSixth, TSeventh)>> QueryAsync<TFirst, TSecond, TThrid, TFourth, TFifth, TSixth, TSeventh>(this IDbConnection conn, SqlBuilder.Template query, IDbTransaction tran = null, CancellationToken cancellationToken = default)
+			=> conn.QueryAsync<TFirst, TSecond, TThrid, TFourth, TFifth, TSixth, TSeventh>(query.RawSql, param: query.Parameters, tran: tran, cancellationToken: cancellationToken);
 
-		public static Task<IEnumerable<(TFirst, TSecond)>> QueryAsync<TFirst, TSecond>(this IDbConnection conn, string rawSql, object param = null, IDbTransaction tran = null)
-			=> conn.QueryAsync<TFirst, TSecond, (TFirst, TSecond)>(rawSql, (first, second) => (first, second), param: param, transaction: tran);
+		public static Task<IEnumerable<(TFirst, TSecond)>> QueryAsync<TFirst, TSecond>(this IDbConnection conn, string rawSql, object param = null, IDbTransaction tran = null, CancellationToken cancellationToken = default)
+			=> conn.QueryAsync<TFirst, TSecond, (TFirst, TSecond)>(new CommandDefinition(rawSql, param, transaction: tran, cancellationToken: cancellationToken), (first, second) => (first, second));
 
-		public static Task<IEnumerable<(TFirst, TSecond, TThird)>> QueryAsync<TFirst, TSecond, TThird>(this IDbConnection conn, string rawSql, object param = null, IDbTransaction tran = null)
-			=> conn.QueryAsync<TFirst, TSecond, TThird, (TFirst, TSecond, TThird)>(rawSql, (first, second, third) => (first, second, third), param: param, transaction: tran);
+		public static Task<IEnumerable<(TFirst, TSecond, TThird)>> QueryAsync<TFirst, TSecond, TThird>(this IDbConnection conn, string rawSql, object param = null, IDbTransaction tran = null, CancellationToken cancellationToken = default)
+			=> conn.QueryAsync<TFirst, TSecond, TThird, (TFirst, TSecond, TThird)>(new CommandDefinition(rawSql, param, transaction: tran, cancellationToken: cancellationToken), (first, second, third) => (first, second, third));
 
-		public static Task<IEnumerable<(TFirst, TSecond, TThird, TFourth)>> QueryAsync<TFirst, TSecond, TThird, TFourth>(this IDbConnection conn, string rawSql, object param = null, IDbTransaction tran = null)
-			=> conn.QueryAsync<TFirst, TSecond, TThird, TFourth, (TFirst, TSecond, TThird, TFourth)>(rawSql, (first, second, third, fourth) => (first, second, third, fourth), param: param, transaction: tran);
+		public static Task<IEnumerable<(TFirst, TSecond, TThird, TFourth)>> QueryAsync<TFirst, TSecond, TThird, TFourth>(this IDbConnection conn, string rawSql, object param = null, IDbTransaction tran = null, CancellationToken cancellationToken = default)
+			=> conn.QueryAsync<TFirst, TSecond, TThird, TFourth, (TFirst, TSecond, TThird, TFourth)>(new CommandDefinition(rawSql, param, transaction: tran, cancellationToken: cancellationToken), (first, second, third, fourth) => (first, second, third, fourth));
 
-		public static Task<IEnumerable<(TFirst, TSecond, TThird, TFourth, TFifth)>> QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth>(this IDbConnection conn, string rawSql, object param, IDbTransaction tran = null)
-			 => conn.QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, (TFirst, TSecond, TThird, TFourth, TFifth)>(rawSql, (first, second, third, fourth, fifth) => (first, second, third, fourth, fifth), param: param, transaction: tran);
+		public static Task<IEnumerable<(TFirst, TSecond, TThird, TFourth, TFifth)>> QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth>(this IDbConnection conn, string rawSql, object param, IDbTransaction tran = null, CancellationToken cancellationToken = default)
+			 => conn.QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, (TFirst, TSecond, TThird, TFourth, TFifth)>(new CommandDefinition(rawSql, param, transaction: tran, cancellationToken: cancellationToken), (first, second, third, fourth, fifth) => (first, second, third, fourth, fifth));
 
-		public static Task<IEnumerable<(TFirst, TSecond, TThird, TFourth, TFifth, TSixth)>> QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth>(this IDbConnection conn, string rawSql, object param = null, IDbTransaction tran = null)
-			 => conn.QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, (TFirst, TSecond, TThird, TFourth, TFifth, TSixth)>(rawSql, (first, second, third, fourth, fifth, sixth) => (first, second, third, fourth, fifth, sixth), param: param, transaction: tran);
+		public static Task<IEnumerable<(TFirst, TSecond, TThird, TFourth, TFifth, TSixth)>> QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth>(this IDbConnection conn, string rawSql, object param = null, IDbTransaction tran = null, CancellationToken cancellationToken = default)
+			 => conn.QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, (TFirst, TSecond, TThird, TFourth, TFifth, TSixth)>(new CommandDefinition(rawSql, param, transaction: tran, cancellationToken: cancellationToken), (first, second, third, fourth, fifth, sixth) => (first, second, third, fourth, fifth, sixth));
 
-		public static Task<IEnumerable<(TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh)>> QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh>(this IDbConnection conn, string rawSql, object param = null, IDbTransaction tran = null)
-			=> conn.QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, (TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh)>(rawSql, (first, second, third, fourth, fifth, sixth, seventh) => (first, second, third, fourth, fifth, sixth, seventh), param: param, transaction: tran);
+		public static Task<IEnumerable<(TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh)>> QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh>(this IDbConnection conn, string rawSql, object param = null, IDbTransaction tran = null, CancellationToken cancellationToken = default)
+			=> conn.QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, (TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh)>(new CommandDefinition(rawSql, param, transaction: tran, cancellationToken: cancellationToken), (first, second, third, fourth, fifth, sixth, seventh) => (first, second, third, fourth, fifth, sixth, seventh));
 
-		public static Task<int> ExecuteAsync(this IDbConnection conn, SqlBuilder.Template query, IDbTransaction tran = null)
-			=> conn.ExecuteAsync(query.RawSql, param: query.Parameters, transaction: tran);
+		public static Task<int> ExecuteAsync(this IDbConnection conn, SqlBuilder.Template query, IDbTransaction tran = null, CancellationToken cancellationToken = default)
+			=> conn.ExecuteAsync(new CommandDefinition(query.RawSql, query.Parameters, transaction: tran, cancellationToken: cancellationToken));
 
 		public static async Task<R> ExecuteAsync<R>(this IDbConnection conn, Func<IDbConnection, Task<R>> function)
 		{

--- a/src/Simpleverse.Repository.Db/DbRepository.cs
+++ b/src/Simpleverse.Repository.Db/DbRepository.cs
@@ -1,9 +1,10 @@
-﻿using Dapper;
+using Dapper;
 using Simpleverse.Repository.Db.Meta;
 using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Simpleverse.Repository.Db
@@ -19,61 +20,61 @@ namespace Simpleverse.Repository.Db
 			_connectionFactory = connectionFactory;
 		}
 
-		public Task<IEnumerable<R>> QueryAsync<R>(SqlBuilder.Template query)
-			=> QueryAsync<R>(query.RawSql, query.Parameters);
+		public Task<IEnumerable<R>> QueryAsync<R>(SqlBuilder.Template query, CancellationToken cancellationToken = default)
+			=> QueryAsync<R>(query.RawSql, query.Parameters, cancellationToken);
 
-		public Task<IEnumerable<dynamic>> QueryAsync(SqlBuilder.Template query)
-			=> QueryAsync(query.RawSql, query.Parameters);
+		public Task<IEnumerable<dynamic>> QueryAsync(SqlBuilder.Template query, CancellationToken cancellationToken = default)
+			=> QueryAsync(query.RawSql, query.Parameters, cancellationToken);
 
-		public Task<IEnumerable<(TFirst, TSecond)>> QueryAsync<TFirst, TSecond>(SqlBuilder.Template query)
-			=> QueryAsync<TFirst, TSecond>(query.RawSql, query.Parameters);
+		public Task<IEnumerable<(TFirst, TSecond)>> QueryAsync<TFirst, TSecond>(SqlBuilder.Template query, CancellationToken cancellationToken = default)
+			=> QueryAsync<TFirst, TSecond>(query.RawSql, query.Parameters, cancellationToken: cancellationToken);
 
-		public Task<IEnumerable<(TFirst, TSecond, TThrid)>> QueryAsync<TFirst, TSecond, TThrid>(SqlBuilder.Template query)
-			=> QueryAsync<TFirst, TSecond, TThrid>(query.RawSql, query.Parameters);
+		public Task<IEnumerable<(TFirst, TSecond, TThrid)>> QueryAsync<TFirst, TSecond, TThrid>(SqlBuilder.Template query, CancellationToken cancellationToken = default)
+			=> QueryAsync<TFirst, TSecond, TThrid>(query.RawSql, query.Parameters, cancellationToken: cancellationToken);
 
-		public Task<IEnumerable<(TFirst, TSecond, TThrid, TFourth)>> QueryAsync<TFirst, TSecond, TThrid, TFourth>(SqlBuilder.Template query)
-			=> QueryAsync<TFirst, TSecond, TThrid, TFourth>(query.RawSql, query.Parameters);
+		public Task<IEnumerable<(TFirst, TSecond, TThrid, TFourth)>> QueryAsync<TFirst, TSecond, TThrid, TFourth>(SqlBuilder.Template query, CancellationToken cancellationToken = default)
+			=> QueryAsync<TFirst, TSecond, TThrid, TFourth>(query.RawSql, query.Parameters, cancellationToken: cancellationToken);
 
-		public Task<IEnumerable<(TFirst, TSecond, TThrid, TFourth, TFifth)>> QueryAsync<TFirst, TSecond, TThrid, TFourth, TFifth>(SqlBuilder.Template query)
-			=> QueryAsync<TFirst, TSecond, TThrid, TFourth, TFifth>(query.RawSql, query.Parameters);
+		public Task<IEnumerable<(TFirst, TSecond, TThrid, TFourth, TFifth)>> QueryAsync<TFirst, TSecond, TThrid, TFourth, TFifth>(SqlBuilder.Template query, CancellationToken cancellationToken = default)
+			=> QueryAsync<TFirst, TSecond, TThrid, TFourth, TFifth>(query.RawSql, query.Parameters, cancellationToken: cancellationToken);
 
-		public Task<IEnumerable<(TFirst, TSecond, TThrid, TFourth, TFifth, TSixth)>> QueryAsync<TFirst, TSecond, TThrid, TFourth, TFifth, TSixth>(SqlBuilder.Template query)
-			=> QueryAsync<TFirst, TSecond, TThrid, TFourth, TFifth, TSixth>(query.RawSql, query.Parameters);
+		public Task<IEnumerable<(TFirst, TSecond, TThrid, TFourth, TFifth, TSixth)>> QueryAsync<TFirst, TSecond, TThrid, TFourth, TFifth, TSixth>(SqlBuilder.Template query, CancellationToken cancellationToken = default)
+			=> QueryAsync<TFirst, TSecond, TThrid, TFourth, TFifth, TSixth>(query.RawSql, query.Parameters, cancellationToken: cancellationToken);
 
-		public Task<IEnumerable<(TFirst, TSecond, TThrid, TFourth, TFifth, TSixth, TSeventh)>> QueryAsync<TFirst, TSecond, TThrid, TFourth, TFifth, TSixth, TSeventh>(SqlBuilder.Template query)
-			=> QueryAsync<TFirst, TSecond, TThrid, TFourth, TFifth, TSixth, TSeventh>(query.RawSql, query.Parameters);
+		public Task<IEnumerable<(TFirst, TSecond, TThrid, TFourth, TFifth, TSixth, TSeventh)>> QueryAsync<TFirst, TSecond, TThrid, TFourth, TFifth, TSixth, TSeventh>(SqlBuilder.Template query, CancellationToken cancellationToken = default)
+			=> QueryAsync<TFirst, TSecond, TThrid, TFourth, TFifth, TSixth, TSeventh>(query.RawSql, query.Parameters, cancellationToken: cancellationToken);
 
-		public virtual async Task<IEnumerable<R>> QueryAsync<R>(string rawSql, object parameters)
+		public virtual async Task<IEnumerable<R>> QueryAsync<R>(string rawSql, object parameters, CancellationToken cancellationToken = default)
 		{
-			return await ExecuteAsync((conn) => conn.QueryAsync<R>(rawSql, param: parameters));
+			return await ExecuteAsync((conn) => conn.QueryAsync<R>(new CommandDefinition(rawSql, parameters, cancellationToken: cancellationToken)));
 		}
 
-		public virtual async Task<IEnumerable<dynamic>> QueryAsync(string rawSql, object parameters)
+		public virtual async Task<IEnumerable<dynamic>> QueryAsync(string rawSql, object parameters, CancellationToken cancellationToken = default)
 		{
-			return await ExecuteAsync((conn) => conn.QueryAsync(rawSql, param: parameters));
+			return await ExecuteAsync((conn) => conn.QueryAsync(new CommandDefinition(rawSql, parameters, cancellationToken: cancellationToken)));
 		}
 
-		public Task<IEnumerable<(TFirst, TSecond)>> QueryAsync<TFirst, TSecond>(string rawSql, object parameters = null)
-			=> ExecuteAsync((conn) => conn.QueryAsync<TFirst, TSecond>(rawSql, param: parameters));
+		public Task<IEnumerable<(TFirst, TSecond)>> QueryAsync<TFirst, TSecond>(string rawSql, object parameters = null, CancellationToken cancellationToken = default)
+			=> ExecuteAsync((conn) => conn.QueryAsync<TFirst, TSecond>(rawSql, param: parameters, cancellationToken: cancellationToken));
 
-		public Task<IEnumerable<(TFirst, TSecond, TThird)>> QueryAsync<TFirst, TSecond, TThird>(string rawSql, object parameters = null)
-			=> ExecuteAsync((conn) => conn.QueryAsync<TFirst, TSecond, TThird>(rawSql, param: parameters));
+		public Task<IEnumerable<(TFirst, TSecond, TThird)>> QueryAsync<TFirst, TSecond, TThird>(string rawSql, object parameters = null, CancellationToken cancellationToken = default)
+			=> ExecuteAsync((conn) => conn.QueryAsync<TFirst, TSecond, TThird>(rawSql, param: parameters, cancellationToken: cancellationToken));
 
-		public Task<IEnumerable<(TFirst, TSecond, TThird, TFourth)>> QueryAsync<TFirst, TSecond, TThird, TFourth>(string rawSql, object parameters = null)
-			=> ExecuteAsync((conn) => conn.QueryAsync<TFirst, TSecond, TThird, TFourth>(rawSql, param: parameters));
+		public Task<IEnumerable<(TFirst, TSecond, TThird, TFourth)>> QueryAsync<TFirst, TSecond, TThird, TFourth>(string rawSql, object parameters = null, CancellationToken cancellationToken = default)
+			=> ExecuteAsync((conn) => conn.QueryAsync<TFirst, TSecond, TThird, TFourth>(rawSql, param: parameters, cancellationToken: cancellationToken));
 
-		public Task<IEnumerable<(TFirst, TSecond, TThird, TFourth, TFifth)>> QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth>(string rawSql, object parameters = null)
-			=> ExecuteAsync((conn) => conn.QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth>(rawSql, param: parameters));
+		public Task<IEnumerable<(TFirst, TSecond, TThird, TFourth, TFifth)>> QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth>(string rawSql, object parameters = null, CancellationToken cancellationToken = default)
+			=> ExecuteAsync((conn) => conn.QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth>(rawSql, param: parameters, cancellationToken: cancellationToken));
 
-		public Task<IEnumerable<(TFirst, TSecond, TThird, TFourth, TFifth, TSixth)>> QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth>(string rawSql, object parameters = null)
-			=> ExecuteAsync((conn) => conn.QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth>(rawSql, param: parameters));
+		public Task<IEnumerable<(TFirst, TSecond, TThird, TFourth, TFifth, TSixth)>> QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth>(string rawSql, object parameters = null, CancellationToken cancellationToken = default)
+			=> ExecuteAsync((conn) => conn.QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth>(rawSql, param: parameters, cancellationToken: cancellationToken));
 
-		public Task<IEnumerable<(TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh)>> QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh>(string rawSql, object parameters = null)
-			=> ExecuteAsync((conn) => conn.QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh>(rawSql, param: parameters));
+		public Task<IEnumerable<(TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh)>> QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh>(string rawSql, object parameters = null, CancellationToken cancellationToken = default)
+			=> ExecuteAsync((conn) => conn.QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh>(rawSql, param: parameters, cancellationToken: cancellationToken));
 
 
-		public Task<int> ExecuteAsync(SqlBuilder.Template query)
-			=> ExecuteAsync((conn) => conn.ExecuteAsync(query));
+		public Task<int> ExecuteAsync(SqlBuilder.Template query, CancellationToken cancellationToken = default)
+			=> ExecuteAsync((conn) => conn.ExecuteAsync(query, cancellationToken: cancellationToken));
 
 		public async Task<R> ExecuteAsync<R>(Func<IDbConnection, Task<R>> function)
 		{

--- a/src/Simpleverse.Repository.Db/Entity/Entity.cs
+++ b/src/Simpleverse.Repository.Db/Entity/Entity.cs
@@ -1,4 +1,4 @@
-﻿using Dapper;
+using Dapper;
 using Dapper.Contrib.Extensions;
 using Simpleverse.Repository.ChangeTracking;
 using Simpleverse.Repository.Db.Extensions.Dapper;
@@ -11,6 +11,7 @@ using System.Data;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Simpleverse.Repository.Db.Entity
@@ -36,77 +37,79 @@ namespace Simpleverse.Repository.Db.Entity
 		#region Get
 
 		public async Task<TModel> GetAsync(dynamic id)
-		{
-			return await Repository.ExecuteAsync<TModel>((conn) => GetAsync(conn, id));
-		}
+			=> await Repository.ExecuteAsync<TModel>((conn) => GetAsync(conn, id));
+
 		public virtual Task<TModel> GetAsync(IDbConnection connection, dynamic id, IDbTransaction transaction = null)
 			=> SqlMapperExtensions.GetAsync<TModel>(connection, id, transaction: transaction);
 
-		public Task<TModel> GetAsync(Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null)
-			=> GetAsync<TModel>(filterSetup, optionsSetup);
+		public Task<TModel> GetAsync(Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null, CancellationToken cancellationToken = default)
+			=> GetAsync<TModel>(filterSetup, optionsSetup, cancellationToken);
 		public Task<TModel> GetAsync(
 			IDbConnection connection,
 			Action<TFilter> filterSetup = null,
 			Action<TOptions> optionsSetup = null,
-			IDbTransaction transaction = null
+			IDbTransaction transaction = null,
+			CancellationToken cancellationToken = default
 		)
-			=> GetAsync<TModel>(connection, filterSetup, optionsSetup, transaction: transaction);
+			=> GetAsync<TModel>(connection, filterSetup, optionsSetup, transaction: transaction, cancellationToken: cancellationToken);
 
-		public async Task<T> GetAsync<T>(Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null)
-			=> (await ListAsync<T>(filterSetup, options => { options.Take = 1; optionsSetup?.Invoke(options); })).FirstOrDefault();
-		public async Task<T> GetAsync<T>(IDbConnection connection, Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null, IDbTransaction transaction = null)
-			=> (await ListAsync<T>(connection, filterSetup, options => { options.Take = 1; optionsSetup?.Invoke(options); }, transaction: transaction)).FirstOrDefault();
+		public async Task<T> GetAsync<T>(Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null, CancellationToken cancellationToken = default)
+			=> (await ListAsync<T>(filterSetup, options => { options.Take = 1; optionsSetup?.Invoke(options); }, cancellationToken)).FirstOrDefault();
+		public async Task<T> GetAsync<T>(IDbConnection connection, Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null, IDbTransaction transaction = null, CancellationToken cancellationToken = default)
+			=> (await ListAsync<T>(connection, filterSetup, options => { options.Take = 1; optionsSetup?.Invoke(options); }, transaction: transaction, cancellationToken: cancellationToken)).FirstOrDefault();
 
 		#endregion
 
 		#region Exists
 
-		public async Task<bool> ExistsAsync(Action<TFilter> filterSetup = null)
-			=> await GetAsync(filterSetup: filterSetup) != null;
-		public async Task<bool> ExistsAsync(IDbConnection connection, Action<TFilter> filterSetup = null, IDbTransaction transaction = null)
-			=> await GetAsync(connection, filterSetup: filterSetup, transaction: transaction) != null;
+		public async Task<bool> ExistsAsync(Action<TFilter> filterSetup = null, CancellationToken cancellationToken = default)
+			=> await GetAsync(filterSetup: filterSetup, cancellationToken: cancellationToken) != null;
+		public async Task<bool> ExistsAsync(IDbConnection connection, Action<TFilter> filterSetup = null, IDbTransaction transaction = null, CancellationToken cancellationToken = default)
+			=> await GetAsync(connection, filterSetup: filterSetup, transaction: transaction, cancellationToken: cancellationToken) != null;
 
 		#endregion
 
 		#region List
 
-		public Task<IEnumerable<TModel>> ListAsync(Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null)
-			=> ListAsync<TModel>(filterSetup, optionsSetup);
+		public Task<IEnumerable<TModel>> ListAsync(Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null, CancellationToken cancellationToken = default)
+			=> ListAsync<TModel>(filterSetup, optionsSetup, cancellationToken);
 		public Task<IEnumerable<TModel>> ListAsync(
 			IDbConnection connection,
 			Action<TFilter> filterSetup = null,
 			Action<TOptions> optionsSetup = null,
-			IDbTransaction transaction = null
+			IDbTransaction transaction = null,
+			CancellationToken cancellationToken = default
 		)
-			=> ListAsync<TModel>(connection, filterSetup, optionsSetup, transaction: transaction);
+			=> ListAsync<TModel>(connection, filterSetup, optionsSetup, transaction: transaction, cancellationToken: cancellationToken);
 
-		public Task<IEnumerable<T>> ListAsync<T>(Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null)
+		public Task<IEnumerable<T>> ListAsync<T>(Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null, CancellationToken cancellationToken = default)
 		{
 			var filter = GetFilter(filterSetup);
 			var options = optionsSetup.Get();
-			return ListAsync<T>(filter, options);
+			return ListAsync<T>(filter, options, cancellationToken);
 		}
 		public Task<IEnumerable<T>> ListAsync<T>(
 			IDbConnection connection,
 			Action<TFilter> filterSetup = null,
 			Action<TOptions> optionsSetup = null,
-			IDbTransaction transaction = null
+			IDbTransaction transaction = null,
+			CancellationToken cancellationToken = default
 		)
 		{
 			var filter = GetFilter(filterSetup);
 			var options = optionsSetup.Get();
-			return ListAsync<T>(connection, filter, options, transaction: transaction);
+			return ListAsync<T>(connection, filter, options, transaction: transaction, cancellationToken: cancellationToken);
 		}
 
-		public Task<IEnumerable<TModel>> ListAsync(TFilter filter, TOptions options)
-			=> ListAsync<TModel>(filter, options);
-		public Task<IEnumerable<TModel>> ListAsync(IDbConnection connection, TFilter filter, TOptions options, IDbTransaction transaction = null)
-			=> ListAsync<TModel>(connection, filter, options, transaction);
+		public Task<IEnumerable<TModel>> ListAsync(TFilter filter, TOptions options, CancellationToken cancellationToken = default)
+			=> ListAsync<TModel>(filter, options, cancellationToken);
+		public Task<IEnumerable<TModel>> ListAsync(IDbConnection connection, TFilter filter, TOptions options, IDbTransaction transaction = null, CancellationToken cancellationToken = default)
+			=> ListAsync<TModel>(connection, filter, options, transaction, cancellationToken);
 
-		public Task<IEnumerable<T>> ListAsync<T>(TFilter filter, TOptions options)
-			=> Repository.ExecuteAsync((conn) => ListAsync<T>(conn, filter, options));
+		public Task<IEnumerable<T>> ListAsync<T>(TFilter filter, TOptions options, CancellationToken cancellationToken = default)
+			=> Repository.ExecuteAsync((conn) => ListAsync<T>(conn, filter, options, cancellationToken: cancellationToken));
 
-		public virtual Task<IEnumerable<T>> ListAsync<T>(IDbConnection connection, TFilter filter, TOptions options, IDbTransaction transaction = null)
+		public virtual Task<IEnumerable<T>> ListAsync<T>(IDbConnection connection, TFilter filter, TOptions options, IDbTransaction transaction = null, CancellationToken cancellationToken = default)
 		{
 			var builder = Source.AsQuery();
 
@@ -123,12 +126,12 @@ namespace Simpleverse.Repository.Db.Entity
 
 				return (Task<IEnumerable<T>>)
 					typeof(DbConnectionExtensions)
-					.GetMethod(nameof(DbConnectionExtensions.QueryAsync), typeArgumentsCount, new[] { typeof(IDbConnection), query.GetType(), typeof(IDbTransaction) })
+					.GetMethod(nameof(DbConnectionExtensions.QueryAsync), typeArgumentsCount, new[] { typeof(IDbConnection), query.GetType(), typeof(IDbTransaction), typeof(CancellationToken) })
 					.MakeGenericMethod(type.GenericTypeArguments)
-					.Invoke(null, new object[] { connection, query, transaction });
+					.Invoke(null, new object[] { connection, query, transaction, cancellationToken });
 			}
 
-			return connection.QueryAsync<T>(query, tran: transaction);
+			return connection.QueryAsync<T>(query, tran: transaction, cancellationToken: cancellationToken);
 		}
 
 		protected virtual void SelectQuery(QueryBuilder<TModel> builder, TFilter filter, TOptions options)
@@ -154,19 +157,20 @@ namespace Simpleverse.Repository.Db.Entity
 
 		#region Add
 
-		public Task<int> AddAsync(TModel model)
-			=> AddAsync(new[] { model });
+		public Task<int> AddAsync(TModel model, CancellationToken cancellationToken = default)
+			=> AddAsync(new[] { model }, cancellationToken);
 
-		public Task<int> AddAsync(IEnumerable<TModel> models)
-			=> AddAsync(models, outputMap: OutputMapper.MapOnce);
+		public Task<int> AddAsync(IEnumerable<TModel> models, CancellationToken cancellationToken = default)
+			=> AddAsync(models, outputMap: OutputMapper.MapOnce, cancellationToken: cancellationToken);
 
 		public async Task<int> AddAsync(
 			IEnumerable<TModel> models,
-			Action<IEnumerable<TModel>, IEnumerable<TModel>, IEnumerable<PropertyInfo>, IEnumerable<PropertyInfo>> outputMap
+			Action<IEnumerable<TModel>, IEnumerable<TModel>, IEnumerable<PropertyInfo>, IEnumerable<PropertyInfo>> outputMap,
+			CancellationToken cancellationToken = default
 		)
 		{
 			return await Repository.ExecuteAsync(
-				(conn) => AddAsync(conn, models, outputMap: outputMap)
+				(conn) => AddAsync(conn, models, outputMap: outputMap, cancellationToken: cancellationToken)
 			);
 		}
 
@@ -174,7 +178,8 @@ namespace Simpleverse.Repository.Db.Entity
 			IDbConnection connection,
 			IEnumerable<TModel> models,
 			Action<IEnumerable<TModel>, IEnumerable<TModel>, IEnumerable<PropertyInfo>, IEnumerable<PropertyInfo>> outputMap = null,
-			IDbTransaction transaction = null
+			IDbTransaction transaction = null,
+			CancellationToken cancellationToken = default
 		)
 		{
 			if (Repository is SqlRepository)
@@ -182,7 +187,8 @@ namespace Simpleverse.Repository.Db.Entity
 				return connection.InsertBulkAsync(
 					models,
 					transaction: transaction,
-					outputMap: outputMap
+					outputMap: outputMap,
+					cancellationToken: cancellationToken
 				);
 			}
 
@@ -198,19 +204,20 @@ namespace Simpleverse.Repository.Db.Entity
 
 		#region ByModel
 
-		public Task<int> UpdateAsync(TModel model)
-			=> UpdateAsync(new[] { model });
+		public Task<int> UpdateAsync(TModel model, CancellationToken cancellationToken = default)
+			=> UpdateAsync(new[] { model }, cancellationToken);
 
-		public Task<int> UpdateAsync(IEnumerable<TModel> models)
-			=> UpdateAsync(models, outputMap: OutputMapper.MapOnce);
+		public Task<int> UpdateAsync(IEnumerable<TModel> models, CancellationToken cancellationToken = default)
+			=> UpdateAsync(models, outputMap: OutputMapper.MapOnce, cancellationToken: cancellationToken);
 
 		public async Task<int> UpdateAsync(
 			IEnumerable<TModel> models,
-			Action<IEnumerable<TModel>, IEnumerable<TModel>, IEnumerable<PropertyInfo>, IEnumerable<PropertyInfo>> outputMap
+			Action<IEnumerable<TModel>, IEnumerable<TModel>, IEnumerable<PropertyInfo>, IEnumerable<PropertyInfo>> outputMap,
+			CancellationToken cancellationToken = default
 		)
 		{
 			return await Repository.ExecuteAsync(
-				(conn) => UpdateAsync(conn, models, outputMap: outputMap)
+				(conn) => UpdateAsync(conn, models, outputMap: outputMap, cancellationToken: cancellationToken)
 			);
 		}
 
@@ -218,7 +225,8 @@ namespace Simpleverse.Repository.Db.Entity
 			IDbConnection connection,
 			IEnumerable<TModel> models,
 			Action<IEnumerable<TModel>, IEnumerable<TModel>, IEnumerable<PropertyInfo>, IEnumerable<PropertyInfo>> outputMap = null,
-			IDbTransaction transaction = null
+			IDbTransaction transaction = null,
+			CancellationToken cancellationToken = default
 		)
 		{
 			if (Repository is SqlRepository)
@@ -226,7 +234,8 @@ namespace Simpleverse.Repository.Db.Entity
 				return await connection.UpdateBulkAsync(
 					models,
 					transaction: transaction,
-					outputMap: outputMap
+					outputMap: outputMap,
+					cancellationToken: cancellationToken
 				);
 			}
 
@@ -243,12 +252,12 @@ namespace Simpleverse.Repository.Db.Entity
 
 		#endregion
 
-		public virtual Task<int> UpdateAsync(Action<TUpdate> updateSetup, Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null)
+		public virtual Task<int> UpdateAsync(Action<TUpdate> updateSetup, Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null, CancellationToken cancellationToken = default)
 			=> Repository.ExecuteAsync(
-				(conn) => UpdateAsync(conn, updateSetup, filterSetup, optionsSetup)
+				(conn) => UpdateAsync(conn, updateSetup, filterSetup, optionsSetup, cancellationToken: cancellationToken)
 			);
 
-		public virtual Task<int> UpdateAsync(IDbConnection connection, Action<TUpdate> updateSetup, Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null, IDbTransaction transaction = null)
+		public virtual Task<int> UpdateAsync(IDbConnection connection, Action<TUpdate> updateSetup, Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null, IDbTransaction transaction = null, CancellationToken cancellationToken = default)
 		{
 			var update = GetUpdate(updateSetup);
 			var filter = GetFilter(filterSetup);
@@ -258,7 +267,7 @@ namespace Simpleverse.Repository.Db.Entity
 			UpdateQuery(builder, update, filter, options);
 
 			var query = UpdateTemplate(builder, update, filter, options);
-			return connection.ExecuteAsync(query, tran: transaction);
+			return connection.ExecuteAsync(query, tran: transaction, cancellationToken: cancellationToken);
 		}
 
 		protected virtual void UpdateQuery(QueryBuilder<TModel> builder, TUpdate update, TFilter filter, TOptions options)
@@ -327,19 +336,20 @@ namespace Simpleverse.Repository.Db.Entity
 
 		#region Upsert
 
-		public Task<int> UpsertAsync(TModel model)
-			=> UpsertAsync(new[] { model });
+		public Task<int> UpsertAsync(TModel model, CancellationToken cancellationToken = default)
+			=> UpsertAsync(new[] { model }, cancellationToken);
 
-		public Task<int> UpsertAsync(IEnumerable<TModel> models)
-			=> UpsertAsync(models, outputMap: OutputMapper.MapOnce);
+		public Task<int> UpsertAsync(IEnumerable<TModel> models, CancellationToken cancellationToken = default)
+			=> UpsertAsync(models, outputMap: OutputMapper.MapOnce, cancellationToken: cancellationToken);
 
 		public async Task<int> UpsertAsync(
 			IEnumerable<TModel> models,
-			Action<IEnumerable<TModel>, IEnumerable<TModel>, IEnumerable<PropertyInfo>, IEnumerable<PropertyInfo>> outputMap
+			Action<IEnumerable<TModel>, IEnumerable<TModel>, IEnumerable<PropertyInfo>, IEnumerable<PropertyInfo>> outputMap,
+			CancellationToken cancellationToken = default
 		)
 		{
 			return await Repository.ExecuteAsync(
-				(conn) => UpsertAsync(conn, models, outputMap: outputMap)
+				(conn) => UpsertAsync(conn, models, outputMap: outputMap, cancellationToken: cancellationToken)
 			);
 		}
 
@@ -347,13 +357,14 @@ namespace Simpleverse.Repository.Db.Entity
 			IDbConnection connection,
 			IEnumerable<TModel> models,
 			Action<IEnumerable<TModel>, IEnumerable<TModel>, IEnumerable<PropertyInfo>, IEnumerable<PropertyInfo>> outputMap = null,
-			IDbTransaction transaction = null
+			IDbTransaction transaction = null,
+			CancellationToken cancellationToken = default
 		)
 		{
 			if (!(Repository is SqlRepository))
 				throw new NotSupportedException("Upsert is not supported on non-SQL repository connections.");
 
-			return connection.UpsertBulkAsync(models, transaction: transaction, outputMap: outputMap);
+			return connection.UpsertBulkAsync(models, transaction: transaction, outputMap: outputMap, cancellationToken: cancellationToken);
 		}
 
 		#endregion
@@ -362,26 +373,27 @@ namespace Simpleverse.Repository.Db.Entity
 
 		#region ByModel
 
-		public async Task<bool> DeleteAsync(TModel model)
+		public async Task<bool> DeleteAsync(TModel model, CancellationToken cancellationToken = default)
 		{
 			return await Repository.ExecuteAsync((conn) => DeleteAsync(conn, model));
 		}
-		public virtual Task<bool> DeleteAsync(IDbConnection connection, TModel model, IDbTransaction transaction = null)
+		public virtual Task<bool> DeleteAsync(IDbConnection connection, TModel model, IDbTransaction transaction = null, CancellationToken cancellationToken = default)
 			=> connection.DeleteAsync(model, transaction: transaction);
 
-		public async Task<int> DeleteAsync(IEnumerable<TModel> models)
+		public async Task<int> DeleteAsync(IEnumerable<TModel> models, CancellationToken cancellationToken = default)
 		{
 			return await Repository.ExecuteAsync(
-				(conn) => DeleteAsync(conn, models)
+				(conn) => DeleteAsync(conn, models, cancellationToken: cancellationToken)
 			);
 		}
-		public virtual async Task<int> DeleteAsync(IDbConnection connection, IEnumerable<TModel> models, IDbTransaction transaction = null)
+		public virtual async Task<int> DeleteAsync(IDbConnection connection, IEnumerable<TModel> models, IDbTransaction transaction = null, CancellationToken cancellationToken = default)
 		{
 			if (Repository is SqlRepository)
 			{
 				return await connection.DeleteBulkAsync(
 					models,
-					transaction: transaction
+					transaction: transaction,
+					cancellationToken: cancellationToken
 				);
 			}
 
@@ -394,13 +406,14 @@ namespace Simpleverse.Repository.Db.Entity
 
 		#endregion
 
-		public Task<int> DeleteAsync(Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null)
-			=> Repository.ExecuteAsync((conn) => DeleteAsync(conn, filterSetup, optionsSetup));
+		public Task<int> DeleteAsync(Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null, CancellationToken cancellationToken = default)
+			=> Repository.ExecuteAsync((conn) => DeleteAsync(conn, filterSetup, optionsSetup, cancellationToken: cancellationToken));
 		public virtual Task<int> DeleteAsync(
 			IDbConnection connection,
 			Action<TFilter> filterSetup = null,
 			Action<TOptions> optionsSetup = null,
-			IDbTransaction transaction = null
+			IDbTransaction transaction = null,
+			CancellationToken cancellationToken = default
 		)
 		{
 			var filter = GetFilter(filterSetup);
@@ -409,7 +422,7 @@ namespace Simpleverse.Repository.Db.Entity
 			DeleteQuery(builder, filter, options);
 
 			var query = DeleteTemplate(builder, options);
-			return connection.ExecuteAsync(query, tran: transaction);
+			return connection.ExecuteAsync(query, tran: transaction, cancellationToken: cancellationToken);
 		}
 
 		protected virtual void DeleteQuery(QueryBuilder<TModel> builder, TFilter filter, TOptions options)
@@ -424,38 +437,39 @@ namespace Simpleverse.Repository.Db.Entity
 
 		#region IAggregate
 
-		#region Min		
+		#region Min
 
-		public Task<TResult?> MinAsync<TResult>(string columnName)
+		public Task<TResult?> MinAsync<TResult>(string columnName, CancellationToken cancellationToken = default)
 			where TResult : struct
-			=> MinAsync<TResult>(Source.Column(columnName), null);
-		public Task<TResult?> MinAsync<TResult>(IDbConnection connection, string columnName, IDbTransaction transaction = null)
+			=> MinAsync<TResult>(Source.Column(columnName), null, cancellationToken);
+		public Task<TResult?> MinAsync<TResult>(IDbConnection connection, string columnName, IDbTransaction transaction = null, CancellationToken cancellationToken = default)
 			where TResult : struct
-			=> MinAsync<TResult>(connection, Source.Column(columnName), null, transaction: transaction);
+			=> MinAsync<TResult>(connection, Source.Column(columnName), null, transaction: transaction, cancellationToken: cancellationToken);
 
-		public Task<TResult?> MinAsync<TResult>(string columnName, Action<TFilter> filterSetup = null)
+		public Task<TResult?> MinAsync<TResult>(string columnName, Action<TFilter> filterSetup = null, CancellationToken cancellationToken = default)
 			where TResult : struct
-			=> MinAsync<TResult>(Source.Column(columnName), filterSetup);
-		public Task<TResult?> MinAsync<TResult>(IDbConnection connection, string columnName, Action<TFilter> filterSetup = null, IDbTransaction transaction = null)
+			=> MinAsync<TResult>(Source.Column(columnName), filterSetup, cancellationToken);
+		public Task<TResult?> MinAsync<TResult>(IDbConnection connection, string columnName, Action<TFilter> filterSetup = null, IDbTransaction transaction = null, CancellationToken cancellationToken = default)
 			where TResult : struct
-			=> MinAsync<TResult>(connection, Source.Column(columnName), filterSetup, transaction: transaction);
+			=> MinAsync<TResult>(connection, Source.Column(columnName), filterSetup, transaction: transaction, cancellationToken: cancellationToken);
 
-		public Task<TResult?> MinAsync<TResult>(Expression<Func<TModel, TResult>> columnExpression, Action<TFilter> filterSetup = null)
+		public Task<TResult?> MinAsync<TResult>(Expression<Func<TModel, TResult>> columnExpression, Action<TFilter> filterSetup = null, CancellationToken cancellationToken = default)
 			where TResult : struct
-			=> MinAsync<TResult>(Source.Column(columnExpression), filterSetup);
-		public Task<TResult?> MinAsync<TResult>(IDbConnection connection, Expression<Func<TModel, TResult>> columnExpression, Action<TFilter> filterSetup = null, IDbTransaction transaction = null)
+			=> MinAsync<TResult>(Source.Column(columnExpression), filterSetup, cancellationToken);
+		public Task<TResult?> MinAsync<TResult>(IDbConnection connection, Expression<Func<TModel, TResult>> columnExpression, Action<TFilter> filterSetup = null, IDbTransaction transaction = null, CancellationToken cancellationToken = default)
 			where TResult : struct
-			=> MinAsync<TResult>(connection, Source.Column(columnExpression), filterSetup, transaction: transaction);
+			=> MinAsync<TResult>(connection, Source.Column(columnExpression), filterSetup, transaction: transaction, cancellationToken: cancellationToken);
 
-		protected virtual Task<TResult?> MinAsync<TResult>(Selector column, Action<TFilter> filterSetup = null)
+		protected virtual Task<TResult?> MinAsync<TResult>(Selector column, Action<TFilter> filterSetup = null, CancellationToken cancellationToken = default)
 			where TResult : struct
-			=> Repository.ExecuteAsyncWithTransaction((conn, tran) => MinAsync<TResult>(conn, column, filterSetup, tran));
+			=> Repository.ExecuteAsyncWithTransaction((conn, tran) => MinAsync<TResult>(conn, column, filterSetup, tran, cancellationToken));
 
 		public virtual Task<TResult?> MinAsync<TResult>(
 			IDbConnection connection,
 			Selector column,
 			Action<TFilter> filterSetup = null,
-			IDbTransaction transaction = null
+			IDbTransaction transaction = null,
+			CancellationToken cancellationToken = default
 		)
 			where TResult : struct
 		{
@@ -472,42 +486,43 @@ namespace Simpleverse.Repository.Db.Entity
 			");
 
 			Filter(builder, GetFilter(filterSetup));
-			return Repository.ExecuteAsync((conn) => conn.QueryFirstOrDefaultAsync<TResult?>(query.RawSql, query.Parameters));
+			return Repository.ExecuteAsync((conn) => conn.QueryFirstOrDefaultAsync<TResult?>(new CommandDefinition(query.RawSql, query.Parameters, cancellationToken: cancellationToken)));
 		}
 
 		#endregion
 
 		#region Max
 
-		public Task<TResult?> MaxAsync<TResult>(string columnName)
+		public Task<TResult?> MaxAsync<TResult>(string columnName, CancellationToken cancellationToken = default)
 			where TResult : struct
-			=> MaxAsync<TResult>(Source.Column(columnName), null);
-		public Task<TResult?> MaxAsync<TResult>(IDbConnection connection, string columnName, IDbTransaction transaction = null)
+			=> MaxAsync<TResult>(Source.Column(columnName), null, cancellationToken);
+		public Task<TResult?> MaxAsync<TResult>(IDbConnection connection, string columnName, IDbTransaction transaction = null, CancellationToken cancellationToken = default)
 			where TResult : struct
-			=> MaxAsync<TResult>(connection, Source.Column(columnName), null, transaction: transaction);
+			=> MaxAsync<TResult>(connection, Source.Column(columnName), null, transaction: transaction, cancellationToken: cancellationToken);
 
-		public Task<TResult?> MaxAsync<TResult>(string columnName, Action<TFilter> filterSetup = null)
+		public Task<TResult?> MaxAsync<TResult>(string columnName, Action<TFilter> filterSetup = null, CancellationToken cancellationToken = default)
 			where TResult : struct
-			=> MaxAsync<TResult>(Source.Column(columnName), filterSetup);
-		public Task<TResult?> MaxAsync<TResult>(IDbConnection connection, string columnName, Action<TFilter> filterSetup = null, IDbTransaction transaction = null)
+			=> MaxAsync<TResult>(Source.Column(columnName), filterSetup, cancellationToken);
+		public Task<TResult?> MaxAsync<TResult>(IDbConnection connection, string columnName, Action<TFilter> filterSetup = null, IDbTransaction transaction = null, CancellationToken cancellationToken = default)
 			where TResult : struct
-			=> MaxAsync<TResult>(connection, Source.Column(columnName), filterSetup, transaction: transaction);
+			=> MaxAsync<TResult>(connection, Source.Column(columnName), filterSetup, transaction: transaction, cancellationToken: cancellationToken);
 
-		public Task<TResult?> MaxAsync<TResult>(Expression<Func<TModel, TResult>> columnExpression, Action<TFilter> filterSetup = null)
+		public Task<TResult?> MaxAsync<TResult>(Expression<Func<TModel, TResult>> columnExpression, Action<TFilter> filterSetup = null, CancellationToken cancellationToken = default)
 			where TResult : struct
-			=> MaxAsync<TResult>(Source.Column(columnExpression), filterSetup);
-		public Task<TResult?> MaxAsync<TResult>(IDbConnection connection, Expression<Func<TModel, TResult>> columnExpression, Action<TFilter> filterSetup = null, IDbTransaction transaction = null)
+			=> MaxAsync<TResult>(Source.Column(columnExpression), filterSetup, cancellationToken);
+		public Task<TResult?> MaxAsync<TResult>(IDbConnection connection, Expression<Func<TModel, TResult>> columnExpression, Action<TFilter> filterSetup = null, IDbTransaction transaction = null, CancellationToken cancellationToken = default)
 			where TResult : struct
-			=> MaxAsync<TResult>(connection, Source.Column(columnExpression), filterSetup, transaction);
+			=> MaxAsync<TResult>(connection, Source.Column(columnExpression), filterSetup, transaction, cancellationToken);
 
-		protected virtual Task<TResult?> MaxAsync<TResult>(Selector column, Action<TFilter> filterSetup = null)
+		protected virtual Task<TResult?> MaxAsync<TResult>(Selector column, Action<TFilter> filterSetup = null, CancellationToken cancellationToken = default)
 			where TResult : struct
-			=> Repository.ExecuteAsync((conn) => MaxAsync<TResult>(conn, column));
+			=> Repository.ExecuteAsync((conn) => MaxAsync<TResult>(conn, column, cancellationToken: cancellationToken));
 		public virtual Task<TResult?> MaxAsync<TResult>(
 			IDbConnection connection,
 			Selector column,
 			Action<TFilter> filterSetup = null,
-			IDbTransaction transaction = null
+			IDbTransaction transaction = null,
+			CancellationToken cancellationToken = default
 		)
 			where TResult : struct
 		{
@@ -525,7 +540,7 @@ namespace Simpleverse.Repository.Db.Entity
 					/**where**/
 			"
 			);
-			return connection.QueryFirstOrDefaultAsync<TResult?>(query.RawSql, query.Parameters, transaction: transaction);
+			return connection.QueryFirstOrDefaultAsync<TResult?>(new CommandDefinition(query.RawSql, query.Parameters, transaction: transaction, cancellationToken: cancellationToken));
 		}
 
 		#endregion
@@ -536,15 +551,17 @@ namespace Simpleverse.Repository.Db.Entity
 
 		public Task<(int Deleted, int Added)> ReplaceAsync(
 			Action<TFilter> filterSetup,
-			IEnumerable<TModel> models
+			IEnumerable<TModel> models,
+			CancellationToken cancellationToken = default
 		)
-			=> Repository.ExecuteAsyncWithTransaction((conn, tran) => ReplaceAsync(conn, tran, filterSetup, models));
+			=> Repository.ExecuteAsyncWithTransaction((conn, tran) => ReplaceAsync(conn, tran, filterSetup, models, cancellationToken));
 
 		public virtual Task<(int Deleted, int Added)> ReplaceAsync(
 			IDbConnection conn,
 			IDbTransaction tran,
 			Action<TFilter> filterSetup,
-			IEnumerable<TModel> models
+			IEnumerable<TModel> models,
+			CancellationToken cancellationToken = default
 		)
 		{
 			return conn.ExecuteAsyncWithTransaction(
@@ -553,7 +570,8 @@ namespace Simpleverse.Repository.Db.Entity
 					var deleted = await DeleteAsync(
 						conn,
 						filterSetup,
-						transaction: tran
+						transaction: tran,
+						cancellationToken: cancellationToken
 					);
 
 					if (models == null)
@@ -563,7 +581,8 @@ namespace Simpleverse.Repository.Db.Entity
 						conn,
 						models,
 						outputMap: OutputMapper.Map,
-						transaction: tran
+						transaction: tran,
+						cancellationToken: cancellationToken
 					);
 
 					return (deleted, added);

--- a/src/Simpleverse.Repository.Db/Entity/Entity.cs
+++ b/src/Simpleverse.Repository.Db/Entity/Entity.cs
@@ -373,11 +373,11 @@ namespace Simpleverse.Repository.Db.Entity
 
 		#region ByModel
 
-		public async Task<bool> DeleteAsync(TModel model, CancellationToken cancellationToken = default)
+		public async Task<bool> DeleteAsync(TModel model)
 		{
 			return await Repository.ExecuteAsync((conn) => DeleteAsync(conn, model));
 		}
-		public virtual Task<bool> DeleteAsync(IDbConnection connection, TModel model, IDbTransaction transaction = null, CancellationToken cancellationToken = default)
+		public virtual Task<bool> DeleteAsync(IDbConnection connection, TModel model, IDbTransaction transaction = null)
 			=> connection.DeleteAsync(model, transaction: transaction);
 
 		public async Task<int> DeleteAsync(IEnumerable<TModel> models, CancellationToken cancellationToken = default)

--- a/src/Simpleverse.Repository.Db/Entity/ProjectedEntity.cs
+++ b/src/Simpleverse.Repository.Db/Entity/ProjectedEntity.cs
@@ -54,8 +54,8 @@ namespace Simpleverse.Repository.Db.Entity
 		public virtual Task<int> DeleteAsync(IDbConnection connection, Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null, IDbTransaction transaction = null, CancellationToken cancellationToken = default)
 			=> _entity.DeleteAsync(connection, filterSetup, optionsSetup, transaction: transaction, cancellationToken: cancellationToken);
 
-		public async Task<bool> DeleteAsync(IDbConnection connection, TProjection model, IDbTransaction transaction = null, CancellationToken cancellationToken = default)
-			=> await DeleteAsync(connection, new[] { model }, transaction, cancellationToken) > 0;
+		public async Task<bool> DeleteAsync(IDbConnection connection, TProjection model, IDbTransaction transaction = null)
+			=> await DeleteAsync(connection, new[] { model }, transaction) > 0;
 
 		public override sealed Task<int> DeleteAsync(IEnumerable<TProjection> models, CancellationToken cancellationToken = default)
 			=> _entity.ExecuteAsyncWithTransaction((conn, tran) => DeleteAsync(conn, models, tran, cancellationToken));

--- a/src/Simpleverse.Repository.Db/Entity/ProjectedEntity.cs
+++ b/src/Simpleverse.Repository.Db/Entity/ProjectedEntity.cs
@@ -1,9 +1,10 @@
-﻿using Simpleverse.Repository.Entity;
+using Simpleverse.Repository.Entity;
 using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Simpleverse.Repository.Db.Entity
@@ -29,38 +30,39 @@ namespace Simpleverse.Repository.Db.Entity
 
 		#region IAdd
 
-		public Task<int> AddAsync(IEnumerable<TProjection> models, Action<IEnumerable<TProjection>, IEnumerable<TProjection>, IEnumerable<PropertyInfo>, IEnumerable<PropertyInfo>> outputMap)
-			=> _entity.ExecuteAsyncWithTransaction((conn, tran) => AddAsync(conn, models, outputMap, tran));
+		public Task<int> AddAsync(IEnumerable<TProjection> models, Action<IEnumerable<TProjection>, IEnumerable<TProjection>, IEnumerable<PropertyInfo>, IEnumerable<PropertyInfo>> outputMap, CancellationToken cancellationToken = default)
+			=> _entity.ExecuteAsyncWithTransaction((conn, tran) => AddAsync(conn, models, outputMap, tran, cancellationToken));
 
 		public virtual Task<int> AddAsync(
 			IDbConnection connection,
 			IEnumerable<TProjection> models,
 			Action<IEnumerable<TProjection>, IEnumerable<TProjection>, IEnumerable<PropertyInfo>, IEnumerable<PropertyInfo>> outputMap = null,
-			IDbTransaction transaction = null
+			IDbTransaction transaction = null,
+			CancellationToken cancellationToken = default
 		)
 		{
-			return _entity.AddAsync(connection, models.Select(x => x.Model), OutputMapRedirect(models, outputMap), transaction: transaction);
+			return _entity.AddAsync(connection, models.Select(x => x.Model), OutputMapRedirect(models, outputMap), transaction: transaction, cancellationToken: cancellationToken);
 		}
 
 		#endregion
 
 		#region IDelete
 
-		public override sealed Task<int> DeleteAsync(Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null)
-			=> _entity.ExecuteAsyncWithTransaction((conn, tran) => DeleteAsync(conn, filterSetup, optionsSetup, tran));
+		public override sealed Task<int> DeleteAsync(Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null, CancellationToken cancellationToken = default)
+			=> _entity.ExecuteAsyncWithTransaction((conn, tran) => DeleteAsync(conn, filterSetup, optionsSetup, tran, cancellationToken));
 
-		public virtual Task<int> DeleteAsync(IDbConnection connection, Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null, IDbTransaction transaction = null)
-			=> _entity.DeleteAsync(connection, filterSetup, optionsSetup, transaction: transaction);
+		public virtual Task<int> DeleteAsync(IDbConnection connection, Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null, IDbTransaction transaction = null, CancellationToken cancellationToken = default)
+			=> _entity.DeleteAsync(connection, filterSetup, optionsSetup, transaction: transaction, cancellationToken: cancellationToken);
 
-		public async Task<bool> DeleteAsync(IDbConnection connection, TProjection model, IDbTransaction transaction = null)
-			=> await DeleteAsync(connection, new[] { model }, transaction) > 0;
+		public async Task<bool> DeleteAsync(IDbConnection connection, TProjection model, IDbTransaction transaction = null, CancellationToken cancellationToken = default)
+			=> await DeleteAsync(connection, new[] { model }, transaction, cancellationToken) > 0;
 
-		public override sealed Task<int> DeleteAsync(IEnumerable<TProjection> models)
-			=> _entity.ExecuteAsyncWithTransaction((conn, tran) => DeleteAsync(conn, models, tran));
+		public override sealed Task<int> DeleteAsync(IEnumerable<TProjection> models, CancellationToken cancellationToken = default)
+			=> _entity.ExecuteAsyncWithTransaction((conn, tran) => DeleteAsync(conn, models, tran, cancellationToken));
 
-		public virtual Task<int> DeleteAsync(IDbConnection connection, IEnumerable<TProjection> models, IDbTransaction transaction = null)
+		public virtual Task<int> DeleteAsync(IDbConnection connection, IEnumerable<TProjection> models, IDbTransaction transaction = null, CancellationToken cancellationToken = default)
 		{
-			return _entity.DeleteAsync(connection, models.Select(x => x.Model), transaction: transaction);
+			return _entity.DeleteAsync(connection, models.Select(x => x.Model), transaction: transaction, cancellationToken: cancellationToken);
 		}
 
 		#endregion
@@ -69,59 +71,59 @@ namespace Simpleverse.Repository.Db.Entity
 
 		#region Exists
 
-		public override sealed Task<bool> ExistsAsync(Action<TFilter> filterSetup = null)
-			=> _entity.ExecuteAsyncWithTransaction((conn, tran) => ExistsAsync(conn, filterSetup, tran));
+		public override sealed Task<bool> ExistsAsync(Action<TFilter> filterSetup = null, CancellationToken cancellationToken = default)
+			=> _entity.ExecuteAsyncWithTransaction((conn, tran) => ExistsAsync(conn, filterSetup, tran, cancellationToken));
 
-		public virtual Task<bool> ExistsAsync(IDbConnection connection, Action<TFilter> filterSetup = null, IDbTransaction transaction = null)
-			=> _entity.ExistsAsync(connection, filterSetup, transaction: transaction);
+		public virtual Task<bool> ExistsAsync(IDbConnection connection, Action<TFilter> filterSetup = null, IDbTransaction transaction = null, CancellationToken cancellationToken = default)
+			=> _entity.ExistsAsync(connection, filterSetup, transaction: transaction, cancellationToken: cancellationToken);
 
 		#endregion
 
 		#region Get
 
-		public async Task<TProjection> GetAsync(IDbConnection connection, Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null, IDbTransaction transaction = null)
+		public async Task<TProjection> GetAsync(IDbConnection connection, Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null, IDbTransaction transaction = null, CancellationToken cancellationToken = default)
 		{
-			var model = await GetAsync<TModel>(connection, filterSetup, optionsSetup, transaction: transaction);
+			var model = await GetAsync<TModel>(connection, filterSetup, optionsSetup, transaction: transaction, cancellationToken: cancellationToken);
 			if (model == null)
 				return default;
 
 			return Instance(model);
 		}
 
-		public override sealed async Task<T> GetAsync<T>(Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null)
-			=> (await ListAsync<T>(filterSetup, options => { options.Take = 1; optionsSetup?.Invoke(options); })).FirstOrDefault();
+		public override sealed async Task<T> GetAsync<T>(Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null, CancellationToken cancellationToken = default)
+			=> (await ListAsync<T>(filterSetup, options => { options.Take = 1; optionsSetup?.Invoke(options); }, cancellationToken)).FirstOrDefault();
 
-		public async Task<T> GetAsync<T>(IDbConnection connection, Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null, IDbTransaction transaction = null)
-			=> (await ListAsync<T>(connection, filterSetup, options => { options.Take = 1; optionsSetup?.Invoke(options); }, transaction: transaction)).FirstOrDefault();
+		public async Task<T> GetAsync<T>(IDbConnection connection, Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null, IDbTransaction transaction = null, CancellationToken cancellationToken = default)
+			=> (await ListAsync<T>(connection, filterSetup, options => { options.Take = 1; optionsSetup?.Invoke(options); }, transaction: transaction, cancellationToken: cancellationToken)).FirstOrDefault();
 
 		#endregion
 
 		#region List
 
-		public Task<IEnumerable<TProjection>> ListAsync(IDbConnection connection, Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null, IDbTransaction transaction = null)
-			=> ListAsync(connection, GetFilter(filterSetup), optionsSetup.Get(), transaction: transaction);
+		public Task<IEnumerable<TProjection>> ListAsync(IDbConnection connection, Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null, IDbTransaction transaction = null, CancellationToken cancellationToken = default)
+			=> ListAsync(connection, GetFilter(filterSetup), optionsSetup.Get(), transaction: transaction, cancellationToken: cancellationToken);
 
-		public Task<IEnumerable<T>> ListAsync<T>(IDbConnection connection, Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null, IDbTransaction transaction = null)
-			=> ListAsync<T>(connection, GetFilter(filterSetup), optionsSetup.Get(), transaction: transaction);
+		public Task<IEnumerable<T>> ListAsync<T>(IDbConnection connection, Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null, IDbTransaction transaction = null, CancellationToken cancellationToken = default)
+			=> ListAsync<T>(connection, GetFilter(filterSetup), optionsSetup.Get(), transaction: transaction, cancellationToken: cancellationToken);
 
-		public override sealed Task<IEnumerable<TProjection>> ListAsync(TFilter filter, TOptions options)
-			=> _entity.ExecuteAsyncWithTransaction((conn, tran) => ListAsync(conn, filter, options, tran));
+		public override sealed Task<IEnumerable<TProjection>> ListAsync(TFilter filter, TOptions options, CancellationToken cancellationToken = default)
+			=> _entity.ExecuteAsyncWithTransaction((conn, tran) => ListAsync(conn, filter, options, tran, cancellationToken));
 
-		public virtual async Task<IEnumerable<TProjection>> ListAsync(IDbConnection connection, TFilter filter, TOptions options, IDbTransaction transaction = null)
+		public virtual async Task<IEnumerable<TProjection>> ListAsync(IDbConnection connection, TFilter filter, TOptions options, IDbTransaction transaction = null, CancellationToken cancellationToken = default)
 		{
-			var models = await _entity.ListAsync(connection, filter, options, transaction);
+			var models = await _entity.ListAsync(connection, filter, options, transaction, cancellationToken);
 			if (models == null)
 				return default;
 
 			return models.Select(Instance);
 		}
 
-		public override sealed Task<IEnumerable<T>> ListAsync<T>(TFilter filter, TOptions options)
-			=> _entity.ExecuteAsyncWithTransaction((conn, tran) => ListAsync<T>(conn, filter, options, tran));
+		public override sealed Task<IEnumerable<T>> ListAsync<T>(TFilter filter, TOptions options, CancellationToken cancellationToken = default)
+			=> _entity.ExecuteAsyncWithTransaction((conn, tran) => ListAsync<T>(conn, filter, options, tran, cancellationToken));
 
-		public virtual Task<IEnumerable<T>> ListAsync<T>(IDbConnection connection, TFilter filter, TOptions options, IDbTransaction transaction = null)
+		public virtual Task<IEnumerable<T>> ListAsync<T>(IDbConnection connection, TFilter filter, TOptions options, IDbTransaction transaction = null, CancellationToken cancellationToken = default)
 		{
-			return _entity.ListAsync<T>(connection, filter, options, transaction: transaction);
+			return _entity.ListAsync<T>(connection, filter, options, transaction: transaction, cancellationToken: cancellationToken);
 		}
 
 		#endregion
@@ -132,27 +134,27 @@ namespace Simpleverse.Repository.Db.Entity
 
 		#region Max
 
-		public override sealed Task<TResult?> MaxAsync<TResult>(string columName, Action<TFilter> filterSetup)
-			=> _entity.ExecuteAsyncWithTransaction((conn, tran) => MaxAsync<TResult>(conn, columName, filterSetup, tran));
+		public override sealed Task<TResult?> MaxAsync<TResult>(string columName, Action<TFilter> filterSetup, CancellationToken cancellationToken = default)
+			=> _entity.ExecuteAsyncWithTransaction((conn, tran) => MaxAsync<TResult>(conn, columName, filterSetup, tran, cancellationToken));
 
-		public Task<TResult?> MaxAsync<TResult>(IDbConnection connection, string columnName, IDbTransaction transaction = null) where TResult : struct
-			=> MaxAsync<TResult>(connection, columnName, null, transaction: transaction);
+		public Task<TResult?> MaxAsync<TResult>(IDbConnection connection, string columnName, IDbTransaction transaction = null, CancellationToken cancellationToken = default) where TResult : struct
+			=> MaxAsync<TResult>(connection, columnName, null, transaction: transaction, cancellationToken: cancellationToken);
 
-		public virtual Task<TResult?> MaxAsync<TResult>(IDbConnection connection, string columnName, Action<TFilter> filterSetup = null, IDbTransaction transaction = null) where TResult : struct
-			=> _entity.MaxAsync<TResult>(connection, columnName, filterSetup, transaction: transaction);
+		public virtual Task<TResult?> MaxAsync<TResult>(IDbConnection connection, string columnName, Action<TFilter> filterSetup = null, IDbTransaction transaction = null, CancellationToken cancellationToken = default) where TResult : struct
+			=> _entity.MaxAsync<TResult>(connection, columnName, filterSetup, transaction: transaction, cancellationToken: cancellationToken);
 
 		#endregion
 
 		#region Min
 
-		public override sealed Task<TResult?> MinAsync<TResult>(string columName, Action<TFilter> filterSetup)
-			=> _entity.ExecuteAsyncWithTransaction((conn, tran) => MinAsync<TResult>(conn, columName, filterSetup, tran));
+		public override sealed Task<TResult?> MinAsync<TResult>(string columName, Action<TFilter> filterSetup, CancellationToken cancellationToken = default)
+			=> _entity.ExecuteAsyncWithTransaction((conn, tran) => MinAsync<TResult>(conn, columName, filterSetup, tran, cancellationToken));
 
-		public Task<TResult?> MinAsync<TResult>(IDbConnection connection, string columnName, IDbTransaction transaction = null) where TResult : struct
-			=> MinAsync<TResult>(connection, columnName, null, transaction: transaction);
+		public Task<TResult?> MinAsync<TResult>(IDbConnection connection, string columnName, IDbTransaction transaction = null, CancellationToken cancellationToken = default) where TResult : struct
+			=> MinAsync<TResult>(connection, columnName, null, transaction: transaction, cancellationToken: cancellationToken);
 
-		public Task<TResult?> MinAsync<TResult>(IDbConnection connection, string columnName, Action<TFilter> filterSetup = null, IDbTransaction transaction = null) where TResult : struct
-			=> _entity.MinAsync<TResult>(connection, columnName, filterSetup, transaction: transaction);
+		public Task<TResult?> MinAsync<TResult>(IDbConnection connection, string columnName, Action<TFilter> filterSetup = null, IDbTransaction transaction = null, CancellationToken cancellationToken = default) where TResult : struct
+			=> _entity.MinAsync<TResult>(connection, columnName, filterSetup, transaction: transaction, cancellationToken: cancellationToken);
 
 		#endregion
 
@@ -160,37 +162,37 @@ namespace Simpleverse.Repository.Db.Entity
 
 		#region IReplace
 
-		public override sealed Task<(int Deleted, int Added)> ReplaceAsync(Action<TFilter> filterSetup, IEnumerable<TProjection> models)
-			=> _entity.ExecuteAsyncWithTransaction((conn, tran) => ReplaceAsync(conn, tran, filterSetup, models));
+		public override sealed Task<(int Deleted, int Added)> ReplaceAsync(Action<TFilter> filterSetup, IEnumerable<TProjection> models, CancellationToken cancellationToken = default)
+			=> _entity.ExecuteAsyncWithTransaction((conn, tran) => ReplaceAsync(conn, tran, filterSetup, models, cancellationToken));
 
-		public virtual Task<(int Deleted, int Added)> ReplaceAsync(IDbConnection conn, IDbTransaction tran, Action<TFilter> filterSetup, IEnumerable<TProjection> models)
-			=> _entity.ReplaceAsync(conn, tran, filterSetup, models.Select(x => x.Model));
+		public virtual Task<(int Deleted, int Added)> ReplaceAsync(IDbConnection conn, IDbTransaction tran, Action<TFilter> filterSetup, IEnumerable<TProjection> models, CancellationToken cancellationToken = default)
+			=> _entity.ReplaceAsync(conn, tran, filterSetup, models.Select(x => x.Model), cancellationToken);
 
 		#endregion
 
 		#region IUpdate
 
-		public override sealed Task<int> UpdateAsync(Action<TUpdate> updateSetup, Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null)
-			=> _entity.ExecuteAsyncWithTransaction((conn, tran) => UpdateAsync(conn, updateSetup, filterSetup, optionsSetup, tran));
+		public override sealed Task<int> UpdateAsync(Action<TUpdate> updateSetup, Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null, CancellationToken cancellationToken = default)
+			=> _entity.ExecuteAsyncWithTransaction((conn, tran) => UpdateAsync(conn, updateSetup, filterSetup, optionsSetup, tran, cancellationToken));
 
-		public Task<int> UpdateAsync(IDbConnection connection, Action<TUpdate> updateSetup, Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null, IDbTransaction transaction = null)
-			=> _entity.UpdateAsync(connection, updateSetup, filterSetup, optionsSetup, transaction: transaction);
+		public Task<int> UpdateAsync(IDbConnection connection, Action<TUpdate> updateSetup, Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null, IDbTransaction transaction = null, CancellationToken cancellationToken = default)
+			=> _entity.UpdateAsync(connection, updateSetup, filterSetup, optionsSetup, transaction: transaction, cancellationToken: cancellationToken);
 
-		public Task<int> UpdateAsync(IEnumerable<TProjection> models, Action<IEnumerable<TProjection>, IEnumerable<TProjection>, IEnumerable<PropertyInfo>, IEnumerable<PropertyInfo>> outputMap)
-			=> _entity.ExecuteAsyncWithTransaction((conn, tran) => UpdateAsync(conn, models, outputMap, tran));
+		public Task<int> UpdateAsync(IEnumerable<TProjection> models, Action<IEnumerable<TProjection>, IEnumerable<TProjection>, IEnumerable<PropertyInfo>, IEnumerable<PropertyInfo>> outputMap, CancellationToken cancellationToken = default)
+			=> _entity.ExecuteAsyncWithTransaction((conn, tran) => UpdateAsync(conn, models, outputMap, tran, cancellationToken));
 
-		public Task<int> UpdateAsync(IDbConnection connection, IEnumerable<TProjection> models, Action<IEnumerable<TProjection>, IEnumerable<TProjection>, IEnumerable<PropertyInfo>, IEnumerable<PropertyInfo>> outputMap = null, IDbTransaction transaction = null)
-			=> _entity.UpdateAsync(connection, models.Select(x => x.Model), OutputMapRedirect(models, outputMap), transaction);
+		public Task<int> UpdateAsync(IDbConnection connection, IEnumerable<TProjection> models, Action<IEnumerable<TProjection>, IEnumerable<TProjection>, IEnumerable<PropertyInfo>, IEnumerable<PropertyInfo>> outputMap = null, IDbTransaction transaction = null, CancellationToken cancellationToken = default)
+			=> _entity.UpdateAsync(connection, models.Select(x => x.Model), OutputMapRedirect(models, outputMap), transaction, cancellationToken);
 
 		#endregion
 
 		#region IUpsert
 
-		public Task<int> UpsertAsync(IEnumerable<TProjection> models, Action<IEnumerable<TProjection>, IEnumerable<TProjection>, IEnumerable<PropertyInfo>, IEnumerable<PropertyInfo>> outputMap)
-			=> _entity.ExecuteAsyncWithTransaction((conn, tran) => UpsertAsync(conn, models, outputMap, tran));
+		public Task<int> UpsertAsync(IEnumerable<TProjection> models, Action<IEnumerable<TProjection>, IEnumerable<TProjection>, IEnumerable<PropertyInfo>, IEnumerable<PropertyInfo>> outputMap, CancellationToken cancellationToken = default)
+			=> _entity.ExecuteAsyncWithTransaction((conn, tran) => UpsertAsync(conn, models, outputMap, tran, cancellationToken));
 
-		public Task<int> UpsertAsync(IDbConnection connection, IEnumerable<TProjection> models, Action<IEnumerable<TProjection>, IEnumerable<TProjection>, IEnumerable<PropertyInfo>, IEnumerable<PropertyInfo>> outputMap = null, IDbTransaction transaction = null)
-			=> _entity.UpsertAsync(connection, models.Select(x => x.Model), outputMap: OutputMapRedirect(models, outputMap), transaction: transaction);
+		public Task<int> UpsertAsync(IDbConnection connection, IEnumerable<TProjection> models, Action<IEnumerable<TProjection>, IEnumerable<TProjection>, IEnumerable<PropertyInfo>, IEnumerable<PropertyInfo>> outputMap = null, IDbTransaction transaction = null, CancellationToken cancellationToken = default)
+			=> _entity.UpsertAsync(connection, models.Select(x => x.Model), outputMap: OutputMapRedirect(models, outputMap), transaction: transaction, cancellationToken: cancellationToken);
 
 		#endregion
 

--- a/src/Simpleverse.Repository.Db/Extensions/TruncateExtensions.cs
+++ b/src/Simpleverse.Repository.Db/Extensions/TruncateExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Data;
+using System.Threading;
 using System.Threading.Tasks;
 using Dapper;
 using Simpleverse.Repository.Db.Meta;
@@ -15,22 +16,24 @@ namespace Simpleverse.Repository.Db.Extensions
 		}
 
 		public static async Task<int> TruncateAsync<T>(
-			this IDbConnection connection
+			this IDbConnection connection,
+			CancellationToken cancellationToken = default
 		)
 		{
 			var typeMeta = TypeMeta.Get<T>();
-			return await connection.TruncateAsync(typeMeta.TableName);
+			return await connection.TruncateAsync(typeMeta.TableName, cancellationToken);
 		}
 
 		public static async Task<int> TruncateAsync(
 			this IDbConnection connection,
-			string tableName
+			string tableName,
+			CancellationToken cancellationToken = default
 		)
 		{
 			var wasClosed = connection.State == ConnectionState.Closed;
 			if (wasClosed) connection.Open();
 
-			var result = await connection.ExecuteAsync($"TRUNCATE TABLE {tableName};");
+			var result = await connection.ExecuteAsync(new CommandDefinition($"TRUNCATE TABLE {tableName};", cancellationToken: cancellationToken));
 
 			if (wasClosed) connection.Close();
 

--- a/src/Simpleverse.Repository.Db/IDbRepository.cs
+++ b/src/Simpleverse.Repository.Db/IDbRepository.cs
@@ -1,13 +1,14 @@
 ﻿using Dapper;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Simpleverse.Repository.Db
 {
 	public interface IDbRepository
 	{
-		Task<int> ExecuteAsync(SqlBuilder.Template query);
-		Task<IEnumerable<dynamic>> QueryAsync(string rawSql, object parameters);
-		Task<IEnumerable<R>> QueryAsync<R>(string rawSql, object parameters);
+		Task<int> ExecuteAsync(SqlBuilder.Template query, CancellationToken cancellationToken = default);
+		Task<IEnumerable<dynamic>> QueryAsync(string rawSql, object parameters, CancellationToken cancellationToken = default);
+		Task<IEnumerable<R>> QueryAsync<R>(string rawSql, object parameters, CancellationToken cancellationToken = default);
 	}
 }

--- a/src/Simpleverse.Repository.Db/Operations/IAddDb.cs
+++ b/src/Simpleverse.Repository.Db/Operations/IAddDb.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Simpleverse.Repository.Db.Operations
@@ -10,12 +11,13 @@ namespace Simpleverse.Repository.Db.Operations
 	public interface IAddDb<T> : IAdd<T>
 		where T : class
 	{
-		Task<int> AddAsync(IEnumerable<T> models, Action<IEnumerable<T>, IEnumerable<T>, IEnumerable<PropertyInfo>, IEnumerable<PropertyInfo>> outputMap);
+		Task<int> AddAsync(IEnumerable<T> models, Action<IEnumerable<T>, IEnumerable<T>, IEnumerable<PropertyInfo>, IEnumerable<PropertyInfo>> outputMap, CancellationToken cancellationToken = default);
 		Task<int> AddAsync(
 			IDbConnection connection,
 			IEnumerable<T> models,
 			Action<IEnumerable<T>, IEnumerable<T>, IEnumerable<PropertyInfo>, IEnumerable<PropertyInfo>> outputMap = null,
-			IDbTransaction transaction = null
+			IDbTransaction transaction = null,
+			CancellationToken cancellationToken = default
 		);
 	}
 }

--- a/src/Simpleverse.Repository.Db/Operations/IAggregateDb.cs
+++ b/src/Simpleverse.Repository.Db/Operations/IAggregateDb.cs
@@ -1,25 +1,26 @@
 ﻿using Simpleverse.Repository.Operations;
 using System;
 using System.Data;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Simpleverse.Repository.Db.Operations
 {
 	public interface IAggregateDb : IAggregate
 	{
-		Task<TResult?> MaxAsync<TResult>(IDbConnection connection, string columnName, IDbTransaction transaction = null)
+		Task<TResult?> MaxAsync<TResult>(IDbConnection connection, string columnName, IDbTransaction transaction = null, CancellationToken cancellationToken = default)
 			where TResult : struct;
 
-		Task<TResult?> MinAsync<TResult>(IDbConnection connection, string columnName, IDbTransaction transaction = null)
+		Task<TResult?> MinAsync<TResult>(IDbConnection connection, string columnName, IDbTransaction transaction = null, CancellationToken cancellationToken = default)
 			where TResult : struct;
 	}
 
 	public interface IAggregateDb<TFilter> : IAggregateDb, IAggregate<TFilter>
 	{
-		Task<TResult?> MaxAsync<TResult>(IDbConnection connection, string columnName, Action<TFilter> filterSetup = null, IDbTransaction transaction = null)
+		Task<TResult?> MaxAsync<TResult>(IDbConnection connection, string columnName, Action<TFilter> filterSetup = null, IDbTransaction transaction = null, CancellationToken cancellationToken = default)
 			where TResult : struct;
 
-		Task<TResult?> MinAsync<TResult>(IDbConnection connection, string columnName, Action<TFilter> filterSetup = null, IDbTransaction transaction = null)
+		Task<TResult?> MinAsync<TResult>(IDbConnection connection, string columnName, Action<TFilter> filterSetup = null, IDbTransaction transaction = null, CancellationToken cancellationToken = default)
 			where TResult : struct;
 	}
 }

--- a/src/Simpleverse.Repository.Db/Operations/IDeleteDb.cs
+++ b/src/Simpleverse.Repository.Db/Operations/IDeleteDb.cs
@@ -10,7 +10,7 @@ namespace Simpleverse.Repository.Db.Operations
 	public interface IDeleteDb<T> : IDelete<T>
 		where T : class
 	{
-		Task<bool> DeleteAsync(IDbConnection connection, T model, IDbTransaction transaction = null, CancellationToken cancellationToken = default);
+		Task<bool> DeleteAsync(IDbConnection connection, T model, IDbTransaction transaction = null);
 		Task<int> DeleteAsync(IDbConnection connection, IEnumerable<T> models, IDbTransaction transaction = null, CancellationToken cancellationToken = default);
 	}
 

--- a/src/Simpleverse.Repository.Db/Operations/IDeleteDb.cs
+++ b/src/Simpleverse.Repository.Db/Operations/IDeleteDb.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Simpleverse.Repository.Db.Operations
@@ -9,8 +10,8 @@ namespace Simpleverse.Repository.Db.Operations
 	public interface IDeleteDb<T> : IDelete<T>
 		where T : class
 	{
-		Task<bool> DeleteAsync(IDbConnection connection, T model, IDbTransaction transaction = null);
-		Task<int> DeleteAsync(IDbConnection connection, IEnumerable<T> models, IDbTransaction transaction = null);
+		Task<bool> DeleteAsync(IDbConnection connection, T model, IDbTransaction transaction = null, CancellationToken cancellationToken = default);
+		Task<int> DeleteAsync(IDbConnection connection, IEnumerable<T> models, IDbTransaction transaction = null, CancellationToken cancellationToken = default);
 	}
 
 	public interface IDeleteDb<TModel, TFilter, TOptions> : IDeleteDb<TModel>, IDelete<TModel, TFilter, TOptions>
@@ -18,6 +19,6 @@ namespace Simpleverse.Repository.Db.Operations
 		where TFilter : class
 		where TOptions : class
 	{
-		Task<int> DeleteAsync(IDbConnection connection, Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null, IDbTransaction transaction = null);
+		Task<int> DeleteAsync(IDbConnection connection, Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null, IDbTransaction transaction = null, CancellationToken cancellationToken = default);
 	}
 }

--- a/src/Simpleverse.Repository.Db/Operations/IQueryExistDb.cs
+++ b/src/Simpleverse.Repository.Db/Operations/IQueryExistDb.cs
@@ -1,6 +1,7 @@
 ﻿using Simpleverse.Repository.Operations;
 using System;
 using System.Data;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Simpleverse.Repository.Db.Operations
@@ -8,6 +9,6 @@ namespace Simpleverse.Repository.Db.Operations
 	public interface IQueryExistDb<TFilter> : IQueryExist<TFilter>
 		where TFilter : class
 	{
-		Task<bool> ExistsAsync(IDbConnection connection, Action<TFilter> filterSetup = null, IDbTransaction transaction = null);
+		Task<bool> ExistsAsync(IDbConnection connection, Action<TFilter> filterSetup = null, IDbTransaction transaction = null, CancellationToken cancellationToken = default);
 	}
 }

--- a/src/Simpleverse.Repository.Db/Operations/IQueryGetDb.cs
+++ b/src/Simpleverse.Repository.Db/Operations/IQueryGetDb.cs
@@ -1,6 +1,7 @@
 ﻿using Simpleverse.Repository.Operations;
 using System;
 using System.Data;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Simpleverse.Repository.Db.Operations
@@ -14,14 +15,16 @@ namespace Simpleverse.Repository.Db.Operations
 			IDbConnection connection,
 			Action<TFilter> filterSetup = null,
 			Action<TOptions> optionsSetup = null,
-			IDbTransaction transaction = null
+			IDbTransaction transaction = null,
+			CancellationToken cancellationToken = default
 		);
 
 		Task<T> GetAsync<T>(
 			IDbConnection connection,
 			Action<TFilter> filterSetup = null,
 			Action<TOptions> optionsSetup = null,
-			IDbTransaction transaction = null
+			IDbTransaction transaction = null,
+			CancellationToken cancellationToken = default
 		);
 	}
 }

--- a/src/Simpleverse.Repository.Db/Operations/IQueryListDb.cs
+++ b/src/Simpleverse.Repository.Db/Operations/IQueryListDb.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Simpleverse.Repository.Db.Operations
@@ -15,28 +16,32 @@ namespace Simpleverse.Repository.Db.Operations
 			IDbConnection connection,
 			Action<TFilter> filterSetup = null,
 			Action<TOptions> optionsSetup = null,
-			IDbTransaction transaction = null
+			IDbTransaction transaction = null,
+			CancellationToken cancellationToken = default
 		);
 
 		Task<IEnumerable<T>> ListAsync<T>(
 			IDbConnection connection,
 			Action<TFilter> filterSetup = null,
 			Action<TOptions> optionsSetup = null,
-			IDbTransaction transaction = null
+			IDbTransaction transaction = null,
+			CancellationToken cancellationToken = default
 		);
 
 		Task<IEnumerable<TModel>> ListAsync(
 			IDbConnection connection,
 			TFilter filter,
 			TOptions options,
-			IDbTransaction transaction = null
+			IDbTransaction transaction = null,
+			CancellationToken cancellationToken = default
 		);
 
 		Task<IEnumerable<T>> ListAsync<T>(
 			IDbConnection connection,
 			TFilter filter,
 			TOptions options,
-			IDbTransaction transaction = null
+			IDbTransaction transaction = null,
+			CancellationToken cancellationToken = default
 		);
 	}
 }

--- a/src/Simpleverse.Repository.Db/Operations/IReplaceDb.cs
+++ b/src/Simpleverse.Repository.Db/Operations/IReplaceDb.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Simpleverse.Repository.Db.Operations
@@ -14,7 +15,8 @@ namespace Simpleverse.Repository.Db.Operations
 			IDbConnection conn,
 			IDbTransaction tran,
 			Action<TFilter> filterSetup,
-			IEnumerable<TModel> models
+			IEnumerable<TModel> models,
+			CancellationToken cancellationToken = default
 		);
 	}
 }

--- a/src/Simpleverse.Repository.Db/Operations/IUpdateDb.cs
+++ b/src/Simpleverse.Repository.Db/Operations/IUpdateDb.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Simpleverse.Repository.Db.Operations
@@ -10,12 +11,13 @@ namespace Simpleverse.Repository.Db.Operations
 	public interface IUpdateDb<T> : IUpdate<T>
 		where T : class
 	{
-		Task<int> UpdateAsync(IEnumerable<T> models, Action<IEnumerable<T>, IEnumerable<T>, IEnumerable<PropertyInfo>, IEnumerable<PropertyInfo>> outputMap);
+		Task<int> UpdateAsync(IEnumerable<T> models, Action<IEnumerable<T>, IEnumerable<T>, IEnumerable<PropertyInfo>, IEnumerable<PropertyInfo>> outputMap, CancellationToken cancellationToken = default);
 		Task<int> UpdateAsync(
 			IDbConnection connection,
 			IEnumerable<T> models,
 			Action<IEnumerable<T>, IEnumerable<T>, IEnumerable<PropertyInfo>, IEnumerable<PropertyInfo>> outputMap = null,
-			IDbTransaction transaction = null
+			IDbTransaction transaction = null,
+			CancellationToken cancellationToken = default
 		);
 	}
 
@@ -24,6 +26,6 @@ namespace Simpleverse.Repository.Db.Operations
 		where TFilter : class
 		where TOptions : class, new()
 	{
-		Task<int> UpdateAsync(IDbConnection connection, Action<TUpdate> updateSetup, Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null, IDbTransaction transaction = null);
+		Task<int> UpdateAsync(IDbConnection connection, Action<TUpdate> updateSetup, Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null, IDbTransaction transaction = null, CancellationToken cancellationToken = default);
 	}
 }

--- a/src/Simpleverse.Repository.Db/Operations/IUpsertDb.cs
+++ b/src/Simpleverse.Repository.Db/Operations/IUpsertDb.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Simpleverse.Repository.Db.Operations
@@ -10,7 +11,7 @@ namespace Simpleverse.Repository.Db.Operations
 	public interface IUpsertDb<T> : IUpsert<T>
 		where T : class
 	{
-		Task<int> UpsertAsync(IEnumerable<T> models, Action<IEnumerable<T>, IEnumerable<T>, IEnumerable<PropertyInfo>, IEnumerable<PropertyInfo>> outputMap);
-		Task<int> UpsertAsync(IDbConnection connection, IEnumerable<T> models, Action<IEnumerable<T>, IEnumerable<T>, IEnumerable<PropertyInfo>, IEnumerable<PropertyInfo>> outputMap = null, IDbTransaction transaction = null);
+		Task<int> UpsertAsync(IEnumerable<T> models, Action<IEnumerable<T>, IEnumerable<T>, IEnumerable<PropertyInfo>, IEnumerable<PropertyInfo>> outputMap, CancellationToken cancellationToken = default);
+		Task<int> UpsertAsync(IDbConnection connection, IEnumerable<T> models, Action<IEnumerable<T>, IEnumerable<T>, IEnumerable<PropertyInfo>, IEnumerable<PropertyInfo>> outputMap = null, IDbTransaction transaction = null, CancellationToken cancellationToken = default);
 	}
 }

--- a/src/Simpleverse.Repository.Db/Simpleverse.Repository.Db.csproj
+++ b/src/Simpleverse.Repository.Db/Simpleverse.Repository.Db.csproj
@@ -30,7 +30,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="All" />
     <None Include="..\..\LICENSE">
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
@@ -43,13 +43,13 @@
 
   <ItemGroup>
     <PackageReference Include="Dapper.Contrib" Version="2.0.78" />
-    <PackageReference Include="Dapper.SqlBuilder" Version="2.0.78" />
-    <PackageReference Include="Enums.NET" Version="4.0.2" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
-    <PackageReference Include="MiniProfiler.Shared" Version="4.3.8" />
-    <PackageReference Include="morelinq" Version="4.1.0" />
-    <PackageReference Include="System.IO.Hashing" Version="7.0.0" />
+    <PackageReference Include="Dapper.SqlBuilder" Version="2.1.66" />
+    <PackageReference Include="Enums.NET" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.5" />
+    <PackageReference Include="MiniProfiler.Shared" Version="4.5.4" />
+    <PackageReference Include="morelinq" Version="4.4.0" />
+    <PackageReference Include="System.IO.Hashing" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Simpleverse.Repository.Db/Simpleverse.Repository.Db.csproj
+++ b/src/Simpleverse.Repository.Db/Simpleverse.Repository.Db.csproj
@@ -45,7 +45,7 @@
     <PackageReference Include="Dapper.Contrib" Version="2.0.78" />
     <PackageReference Include="Dapper.SqlBuilder" Version="2.1.66" />
     <PackageReference Include="Enums.NET" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.5" />
     <PackageReference Include="MiniProfiler.Shared" Version="4.5.4" />
     <PackageReference Include="morelinq" Version="4.4.0" />

--- a/src/Simpleverse.Repository.Db/SqlServer/BulkExtensions.cs
+++ b/src/Simpleverse.Repository.Db/SqlServer/BulkExtensions.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Simpleverse.Repository.Db.SqlServer
@@ -20,7 +21,8 @@ namespace Simpleverse.Repository.Db.SqlServer
 			this IDbConnection connection,
 			IEnumerable<T> entitiesToInsert,
 			SqlTransaction transaction = null,
-			Action<SqlBulkCopy> sqlBulkCopy = null
+			Action<SqlBulkCopy> sqlBulkCopy = null,
+			CancellationToken cancellationToken = default
 		)
 		{
 			var meta = TypeMeta.Get<T>();
@@ -51,7 +53,8 @@ namespace Simpleverse.Repository.Db.SqlServer
 			string tableName,
 			IEnumerable<PropertyInfo> columnsToCopy,
 			IDbTransaction transaction = null,
-			Action<SqlBulkCopy> sqlBulkCopy = null
+			Action<SqlBulkCopy> sqlBulkCopy = null,
+			CancellationToken cancellationToken = default
 		)
 		{
 			if (!columnsToCopy.Any())
@@ -181,7 +184,8 @@ namespace Simpleverse.Repository.Db.SqlServer
 			IEnumerable<T> entitiesToGet,
 			IDbTransaction transaction = null,
 			int? commandTimeout = null,
-			Action<SqlBulkCopy> sqlBulkCopy = null
+			Action<SqlBulkCopy> sqlBulkCopy = null,
+			CancellationToken cancellationToken = default
 		)
 		{
 			if (!entitiesToGet.Any())
@@ -233,7 +237,8 @@ namespace Simpleverse.Repository.Db.SqlServer
 			IDbTransaction transaction = null,
 			int? commandTimeout = null,
 			Action<SqlBulkCopy> sqlBulkCopy = null,
-			Action<IEnumerable<T>, IEnumerable<T>, IEnumerable<PropertyInfo>, IEnumerable<PropertyInfo>> outputMap = null
+			Action<IEnumerable<T>, IEnumerable<T>, IEnumerable<PropertyInfo>, IEnumerable<PropertyInfo>> outputMap = null,
+			CancellationToken cancellationToken = default
 		) where T : class
 		{
 			var entityCount = entitiesToInsert.Count();
@@ -316,7 +321,8 @@ namespace Simpleverse.Repository.Db.SqlServer
 			IDbTransaction transaction = null,
 			int? commandTimeout = null,
 			Action<SqlBulkCopy> sqlBulkCopy = null,
-			Action<IEnumerable<T>, IEnumerable<T>, IEnumerable<PropertyInfo>, IEnumerable<PropertyInfo>> outputMap = null
+			Action<IEnumerable<T>, IEnumerable<T>, IEnumerable<PropertyInfo>, IEnumerable<PropertyInfo>> outputMap = null,
+			CancellationToken cancellationToken = default
 		) where T : class
 		{
 			entitiesToUpdate = entitiesToUpdate.Where(x => x is SqlMapperExtensions.IProxy proxy && !proxy.IsDirty || !(x is SqlMapperExtensions.IProxy));
@@ -382,7 +388,8 @@ namespace Simpleverse.Repository.Db.SqlServer
 			IEnumerable<T> entitiesToDelete,
 			IDbTransaction transaction = null,
 			int? commandTimeout = null,
-			Action<SqlBulkCopy> sqlBulkCopy = null
+			Action<SqlBulkCopy> sqlBulkCopy = null,
+			CancellationToken cancellationToken = default
 		) where T : class
 		{
 			var entityCount = entitiesToDelete.Count();
@@ -427,7 +434,8 @@ namespace Simpleverse.Repository.Db.SqlServer
 			IEnumerable<T> entities,
 			IEnumerable<PropertyInfo> properties,
 			IDbTransaction transaction = null,
-			Action<SqlBulkCopy> sqlBulkCopy = null
+			Action<SqlBulkCopy> sqlBulkCopy = null,
+			CancellationToken cancellationToken = default
 		)
 		{
 			var entityCount = entities.Count();
@@ -479,7 +487,8 @@ namespace Simpleverse.Repository.Db.SqlServer
 			IEnumerable<PropertyInfo> properties,
 			Func<IDbConnection, string, DynamicParameters, IEnumerable<PropertyInfo>, Task<R>> executor,
 			IDbTransaction transaction = null,
-			Action<SqlBulkCopy> sqlBulkCopy = null
+			Action<SqlBulkCopy> sqlBulkCopy = null,
+			CancellationToken cancellationToken = default
 		)
 		{
 			return await connection.ExecuteAsync(

--- a/src/Simpleverse.Repository.Db/SqlServer/BulkExtensions.cs
+++ b/src/Simpleverse.Repository.Db/SqlServer/BulkExtensions.cs
@@ -32,7 +32,8 @@ namespace Simpleverse.Repository.Db.SqlServer
 				meta.TableName,
 				meta.Properties,
 				transaction: transaction,
-				sqlBulkCopy: sqlBulkCopy
+				sqlBulkCopy: sqlBulkCopy,
+				cancellationToken: cancellationToken
 			);
 		}
 
@@ -63,7 +64,7 @@ namespace Simpleverse.Repository.Db.SqlServer
 			if (connection.State != ConnectionState.Open)
 				throw new ArgumentException("Connection is required to be opened by the calling code.");
 
-			var insertedTableName = await connection.CreateTemporaryTableFromTable(tableName, columnsToCopy, transaction);
+			var insertedTableName = await connection.CreateTemporaryTableFromTable(tableName, columnsToCopy, transaction, cancellationToken: cancellationToken);
 
 			if (columnsToCopy.Count() * entitiesToInsert.Count() < 2000 || !(connection is SqlConnection))
 			{
@@ -83,9 +84,7 @@ namespace Simpleverse.Repository.Db.SqlServer
 							";
 
 							await connection.ExecuteAsync(
-								query.ToString(),
-								parameters,
-								transaction: tran
+								new CommandDefinition(query.ToString(), parameters, transaction: tran, cancellationToken: cancellationToken)
 							);
 						}
 
@@ -100,7 +99,7 @@ namespace Simpleverse.Repository.Db.SqlServer
 				{
 					sqlBulkCopy?.Invoke(bulkCopy);
 					bulkCopy.DestinationTableName = insertedTableName;
-					await bulkCopy.WriteToServerAsync(ToDataTable(entitiesToInsert, columnsToCopy).CreateDataReader());
+					await bulkCopy.WriteToServerAsync(ToDataTable(entitiesToInsert, columnsToCopy).CreateDataReader(), cancellationToken);
 				}
 			}
 
@@ -272,7 +271,8 @@ namespace Simpleverse.Repository.Db.SqlServer
 							var outputTarget = await conn.CreateTemporaryTableFromTable(
 								typeMeta.TableName,
 								typeMeta.PropertiesKeyAndExplicit,
-								transaction
+								transaction,
+								cancellationToken: cancellationToken
 							);
 
 							outputSource = outputTarget;
@@ -296,11 +296,13 @@ namespace Simpleverse.Repository.Db.SqlServer
 							);
 						},
 						transaction,
-						commandTimeout
+						commandTimeout,
+						cancellationToken: cancellationToken
 					);
 				},
 				transaction: transaction,
-				sqlBulkCopy: sqlBulkCopy
+				sqlBulkCopy: sqlBulkCopy,
+				cancellationToken: cancellationToken
 			);
 		}
 
@@ -366,11 +368,13 @@ namespace Simpleverse.Repository.Db.SqlServer
 							);
 						},
 						transaction,
-						commandTimeout
+						commandTimeout,
+						cancellationToken: cancellationToken
 					);
 				},
 				transaction: transaction,
-				sqlBulkCopy: sqlBulkCopy
+				sqlBulkCopy: sqlBulkCopy,
+				cancellationToken: cancellationToken
 			);
 		}
 
@@ -417,14 +421,12 @@ namespace Simpleverse.Repository.Db.SqlServer
 					";
 
 					return await connection.ExecuteAsync(
-						query,
-						param: parameters,
-						commandTimeout: commandTimeout,
-						transaction: transaction
+						new CommandDefinition(query, parameters, transaction: transaction, commandTimeout: commandTimeout, cancellationToken: cancellationToken)
 					);
 				},
 				transaction: transaction,
-				sqlBulkCopy: sqlBulkCopy
+				sqlBulkCopy: sqlBulkCopy,
+				cancellationToken: cancellationToken
 			);
 			return result;
 		}
@@ -475,7 +477,8 @@ namespace Simpleverse.Repository.Db.SqlServer
 				typeMeta.TableName,
 				properties,
 				transaction: transaction,
-				sqlBulkCopy: sqlBulkCopy
+				sqlBulkCopy: sqlBulkCopy,
+				cancellationToken: cancellationToken
 			);
 
 			return (insertedTableName, null);
@@ -498,7 +501,8 @@ namespace Simpleverse.Repository.Db.SqlServer
 						entities,
 						properties,
 						transaction: transaction,
-						sqlBulkCopy: sqlBulkCopy
+						sqlBulkCopy: sqlBulkCopy,
+						cancellationToken: cancellationToken
 					);
 
 					return await executor(connection, source, parameters, properties);

--- a/src/Simpleverse.Repository.Db/SqlServer/Merge/MergeExtensions.cs
+++ b/src/Simpleverse.Repository.Db/SqlServer/Merge/MergeExtensions.cs
@@ -6,6 +6,7 @@ using System.Data;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Simpleverse.Repository.Db.SqlServer.Merge
@@ -18,7 +19,8 @@ namespace Simpleverse.Repository.Db.SqlServer.Merge
 			IDbTransaction transaction = null,
 			int? commandTimeout = null,
 			Action<MergeKeyOptions> key = null,
-			Action<IEnumerable<T>, IEnumerable<T>, IEnumerable<PropertyInfo>, IEnumerable<PropertyInfo>> outputMap = null
+			Action<IEnumerable<T>, IEnumerable<T>, IEnumerable<PropertyInfo>, IEnumerable<PropertyInfo>> outputMap = null,
+			CancellationToken cancellationToken = default
 		)
 			where T : class
 		{
@@ -27,7 +29,8 @@ namespace Simpleverse.Repository.Db.SqlServer.Merge
 				transaction: transaction,
 				commandTimeout: commandTimeout,
 				key: key,
-				outputMap: outputMap
+				outputMap: outputMap,
+				cancellationToken: cancellationToken
 			);
 		}
 
@@ -40,7 +43,8 @@ namespace Simpleverse.Repository.Db.SqlServer.Merge
 			Action<MergeActionOptions<T>> matched = null,
 			Action<MergeActionOptions<T>> notMatchedByTarget = null,
 			Action<MergeActionOptions<T>> notMatchedBySource = null,
-			Action<IEnumerable<T>, IEnumerable<T>, IEnumerable<PropertyInfo>, IEnumerable<PropertyInfo>> outputMap = null
+			Action<IEnumerable<T>, IEnumerable<T>, IEnumerable<PropertyInfo>, IEnumerable<PropertyInfo>> outputMap = null,
+			CancellationToken cancellationToken = default
 		)
 			where T : class
 		{
@@ -52,7 +56,8 @@ namespace Simpleverse.Repository.Db.SqlServer.Merge
 				matched: matched,
 				notMatchedByTarget: notMatchedByTarget,
 				notMatchedBySource: notMatchedBySource,
-				outputMap: outputMap
+				outputMap: outputMap,
+				cancellationToken: cancellationToken
 			);
 		}
 
@@ -72,7 +77,8 @@ namespace Simpleverse.Repository.Db.SqlServer.Merge
 			int? commandTimeout = null,
 			Action<SqlBulkCopy> sqlBulkCopy = null,
 			Action<MergeKeyOptions> key = null,
-			Action<IEnumerable<T>, IEnumerable<T>, IEnumerable<PropertyInfo>, IEnumerable<PropertyInfo>> outputMap = null
+			Action<IEnumerable<T>, IEnumerable<T>, IEnumerable<PropertyInfo>, IEnumerable<PropertyInfo>> outputMap = null,
+			CancellationToken cancellationToken = default
 		) where T : class
 		{
 			return await connection.MergeBulkAsync(
@@ -83,7 +89,8 @@ namespace Simpleverse.Repository.Db.SqlServer.Merge
 				key: key,
 				matched: options => options.Update(),
 				notMatchedByTarget: options => options.Insert(),
-				outputMap: outputMap
+				outputMap: outputMap,
+				cancellationToken: cancellationToken
 			);
 		}
 
@@ -106,7 +113,8 @@ namespace Simpleverse.Repository.Db.SqlServer.Merge
 			Action<MergeActionOptions<T>> matched = null,
 			Action<MergeActionOptions<T>> notMatchedByTarget = null,
 			Action<MergeActionOptions<T>> notMatchedBySource = null,
-			Action<IEnumerable<T>, IEnumerable<T>, IEnumerable<PropertyInfo>, IEnumerable<PropertyInfo>> outputMap = null
+			Action<IEnumerable<T>, IEnumerable<T>, IEnumerable<PropertyInfo>, IEnumerable<PropertyInfo>> outputMap = null,
+			CancellationToken cancellationToken = default
 		) where T : class
 		{
 			if (entitiesToMerge == null)
@@ -181,7 +189,8 @@ namespace Simpleverse.Repository.Db.SqlServer.Merge
 						},
 						transaction: transaction,
 						commandTimeout: commandTimeout,
-						outputResultsSplitConditions: new[] { "[ACTION] = 'INSERT'", "[ACTION] = 'UPDATE'" }
+						outputResultsSplitConditions: new[] { "[ACTION] = 'INSERT'", "[ACTION] = 'UPDATE'" },
+						cancellationToken: cancellationToken
 					);
 				},
 				transaction: transaction,

--- a/src/Simpleverse.Repository.Db/SqlServer/OutputMapExtensions.cs
+++ b/src/Simpleverse.Repository.Db/SqlServer/OutputMapExtensions.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Simpleverse.Repository.Db.SqlServer
@@ -21,7 +22,8 @@ namespace Simpleverse.Repository.Db.SqlServer
 			Action<int, IEnumerable<T>> map,
 			IDbTransaction transaction = null,
 			int? commandTimeout = null,
-			IEnumerable<string> outputResultsSplitConditions = null
+			IEnumerable<string> outputResultsSplitConditions = null,
+			CancellationToken cancellationToken = default
 		)
 			where T : class
 		{
@@ -29,10 +31,7 @@ namespace Simpleverse.Repository.Db.SqlServer
 				async (conn, tran) =>
 				{
 					var result = await conn.ExecuteAsync(
-						query,
-						param: parameters,
-						commandTimeout: commandTimeout,
-						transaction: tran
+						new CommandDefinition(query, parameters, transaction: tran, commandTimeout: commandTimeout, cancellationToken: cancellationToken)
 					);
 
 					if (mapGeneratedValues)
@@ -63,10 +62,7 @@ namespace Simpleverse.Repository.Db.SqlServer
 						);
 
 						var outputs = await conn.QueryMultipleAsync(
-							outputSelectQuery,
-							param: parameters,
-							transaction: tran,
-							commandTimeout: commandTimeout
+							new CommandDefinition(outputSelectQuery, parameters, transaction: tran, commandTimeout: commandTimeout, cancellationToken: cancellationToken)
 						);
 
 						outputResultsSplitConditions.ForEach(

--- a/src/Simpleverse.Repository.Db/SqlServer/SqlConnectionExtensions.cs
+++ b/src/Simpleverse.Repository.Db/SqlServer/SqlConnectionExtensions.cs
@@ -17,7 +17,8 @@ namespace Simpleverse.Repository.Db.SqlServer
 			string tableName,
 			IEnumerable<PropertyInfo> columns,
 			IDbTransaction transaction,
-			IEnumerable<string> arbitraryColumns = null
+			IEnumerable<string> arbitraryColumns = null,
+			CancellationToken cancellationToken = default
 		)
 		{
 			var insertedTableName = $"#tbl_{Guid.NewGuid().ToString().Replace("-", string.Empty)}";
@@ -30,11 +31,14 @@ namespace Simpleverse.Repository.Db.SqlServer
 			}
 
 			await connection.ExecuteAsync(
-				$@"SELECT TOP 0 {columnsString} INTO {insertedTableName} FROM {tableName} WITH(NOLOCK)
-				UNION ALL
-				SELECT TOP 0 {columnsString} FROM {tableName} WITH(NOLOCK);
-				",
-				transaction: transaction
+				new CommandDefinition(
+					$@"SELECT TOP 0 {columnsString} INTO {insertedTableName} FROM {tableName} WITH(NOLOCK)
+					UNION ALL
+					SELECT TOP 0 {columnsString} FROM {tableName} WITH(NOLOCK);
+					",
+					transaction: transaction,
+					cancellationToken: cancellationToken
+				)
 			);
 			return insertedTableName;
 		}

--- a/src/Simpleverse.Repository/Entity/ProjectedEntity.cs
+++ b/src/Simpleverse.Repository/Entity/ProjectedEntity.cs
@@ -1,9 +1,10 @@
-﻿using Simpleverse.Repository.ChangeTracking;
+using Simpleverse.Repository.ChangeTracking;
 using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Simpleverse.Repository.Entity
@@ -34,67 +35,67 @@ namespace Simpleverse.Repository.Entity
 
 		#region IAdd
 
-		public Task<int> AddAsync(TProjection model)
-			=> AddAsync(new[] { model });
+		public Task<int> AddAsync(TProjection model, CancellationToken cancellationToken = default)
+			=> AddAsync(new[] { model }, cancellationToken);
 
-		public virtual Task<int> AddAsync(IEnumerable<TProjection> models)
-			=> _entity.AddAsync(models.Select(x => x.Model));
+		public virtual Task<int> AddAsync(IEnumerable<TProjection> models, CancellationToken cancellationToken = default)
+			=> _entity.AddAsync(models.Select(x => x.Model), cancellationToken);
 
 		#endregion
 
 		#region IDelete
 
-		public virtual Task<int> DeleteAsync(Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null)
-			=> _entity.DeleteAsync(filterSetup, optionsSetup);
+		public virtual Task<int> DeleteAsync(Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null, CancellationToken cancellationToken = default)
+			=> _entity.DeleteAsync(filterSetup, optionsSetup, cancellationToken);
 
-		public async Task<bool> DeleteAsync(TProjection model)
-			=> await DeleteAsync(new[] { model }) > 0;
+		public async Task<bool> DeleteAsync(TProjection model, CancellationToken cancellationToken = default)
+			=> await DeleteAsync(new[] { model }, cancellationToken) > 0;
 
-		public virtual Task<int> DeleteAsync(IEnumerable<TProjection> models)
-			=> _entity.DeleteAsync(models.Select(x => x.Model));
+		public virtual Task<int> DeleteAsync(IEnumerable<TProjection> models, CancellationToken cancellationToken = default)
+			=> _entity.DeleteAsync(models.Select(x => x.Model), cancellationToken);
 
 		#endregion
 
 		#region IQuery
 
-		public virtual async Task<bool> ExistsAsync(Action<TFilter> filterSetup = null)
-			 => await GetAsync(filterSetup, null) != null;
+		public virtual async Task<bool> ExistsAsync(Action<TFilter> filterSetup = null, CancellationToken cancellationToken = default)
+			 => await GetAsync(filterSetup, null, cancellationToken) != null;
 
 		#region Get
 
-		public async Task<TProjection> GetAsync(Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null)
+		public async Task<TProjection> GetAsync(Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null, CancellationToken cancellationToken = default)
 		{
-			var model = await GetAsync<TModel>(filterSetup, optionsSetup);
+			var model = await GetAsync<TModel>(filterSetup, optionsSetup, cancellationToken);
 			if (model == null)
 				return null;
 
 			return Instance(model);
 		}
 
-		public virtual async Task<T> GetAsync<T>(Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null)
-			=> (await ListAsync<T>(filterSetup, optionsSetup)).FirstOrDefault();
+		public virtual async Task<T> GetAsync<T>(Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null, CancellationToken cancellationToken = default)
+			=> (await ListAsync<T>(filterSetup, optionsSetup, cancellationToken)).FirstOrDefault();
 
 		#endregion
 
 		#region List
 
-		public Task<IEnumerable<TProjection>> ListAsync(Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null)
-			=> ListAsync(GetFilter(filterSetup), optionsSetup.Get());
+		public Task<IEnumerable<TProjection>> ListAsync(Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null, CancellationToken cancellationToken = default)
+			=> ListAsync(GetFilter(filterSetup), optionsSetup.Get(), cancellationToken);
 
-		public Task<IEnumerable<T>> ListAsync<T>(Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null)
-			=> ListAsync<T>(GetFilter(filterSetup), optionsSetup.Get());
+		public Task<IEnumerable<T>> ListAsync<T>(Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null, CancellationToken cancellationToken = default)
+			=> ListAsync<T>(GetFilter(filterSetup), optionsSetup.Get(), cancellationToken);
 
-		public virtual async Task<IEnumerable<TProjection>> ListAsync(TFilter filter, TOptions options)
+		public virtual async Task<IEnumerable<TProjection>> ListAsync(TFilter filter, TOptions options, CancellationToken cancellationToken = default)
 		{
-			var models = await _entity.ListAsync(filter, options);
+			var models = await _entity.ListAsync(filter, options, cancellationToken);
 			if (models == null)
 				return default;
 
 			return models.Select(Instance);
 		}
 
-		public virtual Task<IEnumerable<T>> ListAsync<T>(TFilter filter, TOptions options)
-			=> _entity.ListAsync<T>(filter, options);
+		public virtual Task<IEnumerable<T>> ListAsync<T>(TFilter filter, TOptions options, CancellationToken cancellationToken = default)
+			=> _entity.ListAsync<T>(filter, options, cancellationToken);
 
 		#endregion
 
@@ -104,21 +105,21 @@ namespace Simpleverse.Repository.Entity
 
 		#region Max
 
-		public Task<TResult?> MaxAsync<TResult>(string columnName) where TResult : struct
-			=> MaxAsync<TResult>(columnName, null);
+		public Task<TResult?> MaxAsync<TResult>(string columnName, CancellationToken cancellationToken = default) where TResult : struct
+			=> MaxAsync<TResult>(columnName, null, cancellationToken);
 
-		public virtual Task<TResult?> MaxAsync<TResult>(string columName, Action<TFilter> filterSetup) where TResult : struct
-			=> _entity.MaxAsync<TResult>(columName, filterSetup);
+		public virtual Task<TResult?> MaxAsync<TResult>(string columName, Action<TFilter> filterSetup, CancellationToken cancellationToken = default) where TResult : struct
+			=> _entity.MaxAsync<TResult>(columName, filterSetup, cancellationToken);
 
 		#endregion
 
 		#region Min
 
-		public Task<TResult?> MinAsync<TResult>(string columnName) where TResult : struct
-			=> MinAsync<TResult>(columnName, null);
+		public Task<TResult?> MinAsync<TResult>(string columnName, CancellationToken cancellationToken = default) where TResult : struct
+			=> MinAsync<TResult>(columnName, null, cancellationToken);
 
-		public virtual Task<TResult?> MinAsync<TResult>(string columName, Action<TFilter> filterSetup) where TResult : struct
-			=> _entity.MinAsync<TResult>(columName, filterSetup);
+		public virtual Task<TResult?> MinAsync<TResult>(string columName, Action<TFilter> filterSetup, CancellationToken cancellationToken = default) where TResult : struct
+			=> _entity.MinAsync<TResult>(columName, filterSetup, cancellationToken);
 
 		#endregion
 
@@ -126,31 +127,31 @@ namespace Simpleverse.Repository.Entity
 
 		#region IDelete
 
-		public virtual Task<(int Deleted, int Added)> ReplaceAsync(Action<TFilter> filterSetup, IEnumerable<TProjection> models)
-			=> _entity.ReplaceAsync(filterSetup, models.Select(x => x.Model));
+		public virtual Task<(int Deleted, int Added)> ReplaceAsync(Action<TFilter> filterSetup, IEnumerable<TProjection> models, CancellationToken cancellationToken = default)
+			=> _entity.ReplaceAsync(filterSetup, models.Select(x => x.Model), cancellationToken);
 
 		#endregion
 
 		#region IUpdate
 
-		public virtual Task<int> UpdateAsync(Action<TUpdate> updateSetup, Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null)
-			=> _entity.UpdateAsync(updateSetup, filterSetup, optionsSetup);
+		public virtual Task<int> UpdateAsync(Action<TUpdate> updateSetup, Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null, CancellationToken cancellationToken = default)
+			=> _entity.UpdateAsync(updateSetup, filterSetup, optionsSetup, cancellationToken);
 
-		public Task<int> UpdateAsync(TProjection model)
-			=> UpdateAsync(new[] { model });
+		public Task<int> UpdateAsync(TProjection model, CancellationToken cancellationToken = default)
+			=> UpdateAsync(new[] { model }, cancellationToken);
 
-		public virtual Task<int> UpdateAsync(IEnumerable<TProjection> models)
-			=> _entity.UpdateAsync(models.Select(x => x.Model));
+		public virtual Task<int> UpdateAsync(IEnumerable<TProjection> models, CancellationToken cancellationToken = default)
+			=> _entity.UpdateAsync(models.Select(x => x.Model), cancellationToken);
 
 		#endregion
 
 		#region IUpsert
 
-		public Task<int> UpsertAsync(TProjection model)
-			=> UpsertAsync(new[] { model });
+		public Task<int> UpsertAsync(TProjection model, CancellationToken cancellationToken = default)
+			=> UpsertAsync(new[] { model }, cancellationToken);
 
-		public virtual Task<int> UpsertAsync(IEnumerable<TProjection> models)
-			=> _entity.UpsertAsync(models.Select(x => x.Model));
+		public virtual Task<int> UpsertAsync(IEnumerable<TProjection> models, CancellationToken cancellationToken = default)
+			=> _entity.UpsertAsync(models.Select(x => x.Model), cancellationToken);
 
 		#endregion
 

--- a/src/Simpleverse.Repository/Entity/ProjectedEntity.cs
+++ b/src/Simpleverse.Repository/Entity/ProjectedEntity.cs
@@ -48,8 +48,8 @@ namespace Simpleverse.Repository.Entity
 		public virtual Task<int> DeleteAsync(Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null, CancellationToken cancellationToken = default)
 			=> _entity.DeleteAsync(filterSetup, optionsSetup, cancellationToken);
 
-		public async Task<bool> DeleteAsync(TProjection model, CancellationToken cancellationToken = default)
-			=> await DeleteAsync(new[] { model }, cancellationToken) > 0;
+		public async Task<bool> DeleteAsync(TProjection model)
+			=> await DeleteAsync(new[] { model }) > 0;
 
 		public virtual Task<int> DeleteAsync(IEnumerable<TProjection> models, CancellationToken cancellationToken = default)
 			=> _entity.DeleteAsync(models.Select(x => x.Model), cancellationToken);

--- a/src/Simpleverse.Repository/Operations/IAdd.cs
+++ b/src/Simpleverse.Repository/Operations/IAdd.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Simpleverse.Repository.Operations
@@ -6,7 +7,7 @@ namespace Simpleverse.Repository.Operations
 	public interface IAdd<T>
 		where T : class
 	{
-		Task<int> AddAsync(T model);
-		Task<int> AddAsync(IEnumerable<T> models);
+		Task<int> AddAsync(T model, CancellationToken cancellationToken = default);
+		Task<int> AddAsync(IEnumerable<T> models, CancellationToken cancellationToken = default);
 	}
 }

--- a/src/Simpleverse.Repository/Operations/IAggregate.cs
+++ b/src/Simpleverse.Repository/Operations/IAggregate.cs
@@ -1,23 +1,24 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Simpleverse.Repository.Operations
 {
 	public interface IAggregate
 	{
-		Task<TResult?> MaxAsync<TResult>(string columnName)
+		Task<TResult?> MaxAsync<TResult>(string columnName, CancellationToken cancellationToken = default)
 			where TResult : struct;
 
-		Task<TResult?> MinAsync<TResult>(string columnName)
+		Task<TResult?> MinAsync<TResult>(string columnName, CancellationToken cancellationToken = default)
 			where TResult : struct;
 	}
 
 	public interface IAggregate<TFilter> : IAggregate
 	{
-		Task<TResult?> MaxAsync<TResult>(string columnName, Action<TFilter> filterSetup = null)
+		Task<TResult?> MaxAsync<TResult>(string columnName, Action<TFilter> filterSetup = null, CancellationToken cancellationToken = default)
 			where TResult : struct;
 
-		Task<TResult?> MinAsync<TResult>(string columnName, Action<TFilter> filterSetup = null)
+		Task<TResult?> MinAsync<TResult>(string columnName, Action<TFilter> filterSetup = null, CancellationToken cancellationToken = default)
 			where TResult : struct;
 	}
 }

--- a/src/Simpleverse.Repository/Operations/IDelete.cs
+++ b/src/Simpleverse.Repository/Operations/IDelete.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Simpleverse.Repository.Operations
@@ -7,8 +8,8 @@ namespace Simpleverse.Repository.Operations
 	public interface IDelete<T>
 		where T : class
 	{
-		Task<bool> DeleteAsync(T model);
-		Task<int> DeleteAsync(IEnumerable<T> models);
+		Task<bool> DeleteAsync(T model, CancellationToken cancellationToken = default);
+		Task<int> DeleteAsync(IEnumerable<T> models, CancellationToken cancellationToken = default);
 	}
 
 	public interface IDelete<TModel, TFilter, TOptions> : IDelete<TModel>
@@ -16,6 +17,6 @@ namespace Simpleverse.Repository.Operations
 		where TFilter : class
 		where TOptions : class
 	{
-		Task<int> DeleteAsync(Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null);
+		Task<int> DeleteAsync(Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null, CancellationToken cancellationToken = default);
 	}
 }

--- a/src/Simpleverse.Repository/Operations/IDelete.cs
+++ b/src/Simpleverse.Repository/Operations/IDelete.cs
@@ -8,7 +8,7 @@ namespace Simpleverse.Repository.Operations
 	public interface IDelete<T>
 		where T : class
 	{
-		Task<bool> DeleteAsync(T model, CancellationToken cancellationToken = default);
+		Task<bool> DeleteAsync(T model);
 		Task<int> DeleteAsync(IEnumerable<T> models, CancellationToken cancellationToken = default);
 	}
 

--- a/src/Simpleverse.Repository/Operations/IQueryExist.cs
+++ b/src/Simpleverse.Repository/Operations/IQueryExist.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Simpleverse.Repository.Operations
@@ -6,6 +7,6 @@ namespace Simpleverse.Repository.Operations
 	public interface IQueryExist<TFilter>
 		where TFilter : class
 	{
-		Task<bool> ExistsAsync(Action<TFilter> filterSetup = null);
+		Task<bool> ExistsAsync(Action<TFilter> filterSetup = null, CancellationToken cancellationToken = default);
 	}
 }

--- a/src/Simpleverse.Repository/Operations/IQueryGet.cs
+++ b/src/Simpleverse.Repository/Operations/IQueryGet.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Simpleverse.Repository.Operations
@@ -8,8 +9,8 @@ namespace Simpleverse.Repository.Operations
 		where TFilter : class
 		where TOptions : class
 	{
-		Task<TModel> GetAsync(Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null);
+		Task<TModel> GetAsync(Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null, CancellationToken cancellationToken = default);
 
-		Task<T> GetAsync<T>(Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null);
+		Task<T> GetAsync<T>(Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null, CancellationToken cancellationToken = default);
 	}
 }

--- a/src/Simpleverse.Repository/Operations/IQueryList.cs
+++ b/src/Simpleverse.Repository/Operations/IQueryList.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Simpleverse.Repository.Operations
@@ -9,12 +10,12 @@ namespace Simpleverse.Repository.Operations
 		where TFilter : class
 		where TOptions : class
 	{
-		Task<IEnumerable<TModel>> ListAsync(Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null);
+		Task<IEnumerable<TModel>> ListAsync(Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null, CancellationToken cancellationToken = default);
 
-		Task<IEnumerable<T>> ListAsync<T>(Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null);
+		Task<IEnumerable<T>> ListAsync<T>(Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null, CancellationToken cancellationToken = default);
 
-		Task<IEnumerable<TModel>> ListAsync(TFilter filter, TOptions options);
+		Task<IEnumerable<TModel>> ListAsync(TFilter filter, TOptions options, CancellationToken cancellationToken = default);
 
-		Task<IEnumerable<T>> ListAsync<T>(TFilter filter, TOptions options);
+		Task<IEnumerable<T>> ListAsync<T>(TFilter filter, TOptions options, CancellationToken cancellationToken = default);
 	}
 }

--- a/src/Simpleverse.Repository/Operations/IReplace.cs
+++ b/src/Simpleverse.Repository/Operations/IReplace.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Simpleverse.Repository.Operations
@@ -10,7 +11,8 @@ namespace Simpleverse.Repository.Operations
 	{
 		Task<(int Deleted, int Added)> ReplaceAsync(
 			Action<TFilter> filterSetup,
-			IEnumerable<TModel> models
+			IEnumerable<TModel> models,
+			CancellationToken cancellationToken = default
 		);
 	}
 }

--- a/src/Simpleverse.Repository/Operations/IUpdate.cs
+++ b/src/Simpleverse.Repository/Operations/IUpdate.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Simpleverse.Repository.Operations
@@ -7,8 +8,8 @@ namespace Simpleverse.Repository.Operations
 	public interface IUpdate<T>
 		where T : class
 	{
-		Task<int> UpdateAsync(T model);
-		Task<int> UpdateAsync(IEnumerable<T> models);
+		Task<int> UpdateAsync(T model, CancellationToken cancellationToken = default);
+		Task<int> UpdateAsync(IEnumerable<T> models, CancellationToken cancellationToken = default);
 	}
 
 	public interface IUpdate<TUpdate, TFilter, TOptions>
@@ -16,6 +17,6 @@ namespace Simpleverse.Repository.Operations
 		where TFilter : class
 		where TOptions : class
 	{
-		Task<int> UpdateAsync(Action<TUpdate> updateSetup, Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null);
+		Task<int> UpdateAsync(Action<TUpdate> updateSetup, Action<TFilter> filterSetup = null, Action<TOptions> optionsSetup = null, CancellationToken cancellationToken = default);
 	}
 }

--- a/src/Simpleverse.Repository/Operations/IUpsert.cs
+++ b/src/Simpleverse.Repository/Operations/IUpsert.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Simpleverse.Repository.Operations
@@ -6,7 +7,7 @@ namespace Simpleverse.Repository.Operations
 	public interface IUpsert<T> : IAdd<T>, IUpdate<T>
 		where T : class
 	{
-		Task<int> UpsertAsync(T model);
-		Task<int> UpsertAsync(IEnumerable<T> models);
+		Task<int> UpsertAsync(T model, CancellationToken cancellationToken = default);
+		Task<int> UpsertAsync(IEnumerable<T> models, CancellationToken cancellationToken = default);
 	}
 }


### PR DESCRIPTION
 Body:
  ## Summary

  - Added `CancellationToken cancellationToken = default` parameter to every async method across all interfaces (`IAdd`, `IDelete`, `IUpdate`, `IUpsert`, `IReplace`, `IQueryGet`, `IQueryList`, `IQueryExist`,
  `IAggregate`) and their Db-layer counterparts (`IAddDb`, `IDeleteDb`, etc.)
  - Threaded the token through the entire call chain down to Dapper using `CommandDefinition` — the only way to pass a cancellation token in Dapper 2.0.x
  - Updated `DbConnectionExtensions`, `DbRepository`, `Entity`, `ProjectedEntity`, `BulkExtensions`, `MergeExtensions`, `OutputMapExtensions`, `TruncateExtensions`, and `SqlConnectionExtensions` to forward the
   token at every level
  - Reflection-based tuple dispatch in `Entity.ListAsync<T>` updated to include `CancellationToken` in the method lookup type array and invocation arguments

  ## Tests

  - Added `CancellationTokenTests` with 8 tests verifying that passing a pre-cancelled `CancellationToken(canceled: true)` causes `OperationCanceledException` for: `ListAsync`, `GetAsync`, `AddAsync`,
  `UpdateAsync`, `DeleteAsync`, `ExistsAsync`, `DbRepository.QueryAsync`, `DbRepository.ExecuteAsync`

  ## Test plan

  - [x] Run `CancellationTokenTests` against a SQL Server instance to confirm all 8 tests pass
  - [x] Run existing test suite to confirm no regressions